### PR TITLE
Bandaid Solution for Yelp v2 -> v3

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,17071 @@
+[
+    {
+        "alias": "3dprinting",
+        "title": "3D Printing",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "abruzzese",
+        "title": "Abruzzese",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "absinthebars",
+        "title": "Absinthe Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_whitelist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "acaibowls",
+        "title": "Acai Bowls",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "TR",
+            "AR",
+            "MX",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "accessories",
+        "title": "Accessories",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "accountants",
+        "title": "Accountants",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "acnetreatment",
+        "title": "Acne Treatment",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "active",
+        "title": "Active Life",
+        "parents": []
+    },
+    {
+        "alias": "acupuncture",
+        "title": "Acupuncture",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "addictionmedicine",
+        "title": "Addiction Medicine",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "adoptionservices",
+        "title": "Adoption Services",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "adult",
+        "title": "Adult",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "adultedu",
+        "title": "Adult Education",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "adultentertainment",
+        "title": "Adult Entertainment",
+        "parents": [
+            "nightlife"
+        ]
+    },
+    {
+        "alias": "advertising",
+        "title": "Advertising",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "aerialfitness",
+        "title": "Aerial Fitness",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "aerialtours",
+        "title": "Aerial Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "aestheticians",
+        "title": "Aestheticians",
+        "parents": [
+            "medicalspa"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "afghani",
+        "title": "Afghan",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "MX",
+            "TR"
+        ]
+    },
+    {
+        "alias": "african",
+        "title": "African",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "afrobrazilian",
+        "title": "Afro-Brazilian",
+        "parents": [
+            "religiousorgs"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "agriturismi",
+        "title": "Agriturismi",
+        "parents": [
+            "hotels"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "TW",
+            "ES",
+            "FR",
+            "AR",
+            "MX",
+            "CZ",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "aircraftdealers",
+        "title": "Aircraft Dealers",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "US",
+            "CZ",
+            "PT"
+        ]
+    },
+    {
+        "alias": "aircraftrepairs",
+        "title": "Aircraft Repairs",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "airductcleaning",
+        "title": "Air Duct Cleaning",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "MY",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "PH",
+            "ES",
+            "CA",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "airlines",
+        "title": "Airlines",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "airport_shuttles",
+        "title": "Airport Shuttles",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "airportlounges",
+        "title": "Airport Lounges",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "airports",
+        "title": "Airports",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "airportterminals",
+        "title": "Airport Terminals",
+        "parents": [
+            "airports"
+        ]
+    },
+    {
+        "alias": "airsoft",
+        "title": "Airsoft",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "alentejo",
+        "title": "Alentejo",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "algarve",
+        "title": "Algarve",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "allergist",
+        "title": "Allergists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "alsatian",
+        "title": "Alsatian",
+        "parents": [
+            "french"
+        ],
+        "country_whitelist": [
+            "FR",
+            "DE"
+        ]
+    },
+    {
+        "alias": "alternativemedicine",
+        "title": "Alternative Medicine",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "CH",
+            "JP",
+            "AT",
+            "TW",
+            "ES",
+            "HK",
+            "MX",
+            "CL",
+            "MY",
+            "PH",
+            "PT",
+            "AR",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "altoatesine",
+        "title": "Altoatesine",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "amateursportsteams",
+        "title": "Amateur Sports Teams",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "amusementparks",
+        "title": "Amusement Parks",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "andalusian",
+        "title": "Andalusian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "IT",
+            "ES"
+        ]
+    },
+    {
+        "alias": "anesthesiologists",
+        "title": "Anesthesiologists",
+        "parents": [
+            "physicians"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT",
+            "SE",
+            "FR",
+            "BE",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "animalassistedtherapy",
+        "title": "Animal Assisted Therapy",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "animalholistic",
+        "title": "Holistic Animal Care",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "animalphysicaltherapy",
+        "title": "Animal Physical Therapy",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "animalshelters",
+        "title": "Animal Shelters",
+        "parents": [
+            "pets"
+        ]
+    },
+    {
+        "alias": "antiques",
+        "title": "Antiques",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "apartmentagents",
+        "title": "Apartment Agents",
+        "parents": [
+            "realestateagents"
+        ]
+    },
+    {
+        "alias": "apartments",
+        "title": "Apartments",
+        "parents": [
+            "realestate"
+        ]
+    },
+    {
+        "alias": "appliances",
+        "title": "Appliances",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "appraisalservices",
+        "title": "Appraisal Services",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "apulian",
+        "title": "Apulian",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "aquariums",
+        "title": "Aquariums",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "aquariumservices",
+        "title": "Aquarium Services",
+        "parents": [
+            "petservices"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "arabian",
+        "title": "Arabian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "DK"
+        ]
+    },
+    {
+        "alias": "arabpizza",
+        "title": "Arab Pizza",
+        "parents": [
+            "arabian"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "arcades",
+        "title": "Arcades",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "archery",
+        "title": "Archery",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "architects",
+        "title": "Architects",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "architecturaltours",
+        "title": "Architectural Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "argentine",
+        "title": "Argentine",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "armenian",
+        "title": "Armenian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "GB",
+            "ES",
+            "US",
+            "FR",
+            "AR",
+            "BE",
+            "CZ",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "arroceria_paella",
+        "title": "Arroceria / Paella",
+        "parents": [
+            "spanish"
+        ],
+        "country_whitelist": [
+            "ES"
+        ]
+    },
+    {
+        "alias": "artclasses",
+        "title": "Art Classes",
+        "parents": [
+            "education"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "artificialturf",
+        "title": "Artificial Turf",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "artmuseums",
+        "title": "Art Museums",
+        "parents": [
+            "museums"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "artrestoration",
+        "title": "Art Restoration",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "arts",
+        "title": "Arts & Entertainment",
+        "parents": []
+    },
+    {
+        "alias": "artsandcrafts",
+        "title": "Arts & Crafts",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "artschools",
+        "title": "Art Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "artspacerentals",
+        "title": "Art Space Rentals",
+        "parents": [
+            "realestate"
+        ],
+        "country_whitelist": [
+            "SE",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "US",
+            "HK",
+            "IT"
+        ]
+    },
+    {
+        "alias": "artsupplies",
+        "title": "Art Supplies",
+        "parents": [
+            "artsandcrafts"
+        ]
+    },
+    {
+        "alias": "arttours",
+        "title": "Art Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "asianfusion",
+        "title": "Asian Fusion",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "assistedliving",
+        "title": "Assisted Living Facilities",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "astrologers",
+        "title": "Astrologers",
+        "parents": [
+            "psychic_astrology"
+        ]
+    },
+    {
+        "alias": "asturian",
+        "title": "Asturian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "ES"
+        ]
+    },
+    {
+        "alias": "ateliers",
+        "title": "Ateliers",
+        "parents": [
+            "artsandcrafts"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "CH",
+            "JP",
+            "AT",
+            "NL",
+            "DK",
+            "BE",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "attractionfarms",
+        "title": "Attraction Farms",
+        "parents": [
+            "farms"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "AT",
+            "ES",
+            "PT",
+            "US",
+            "DK",
+            "BR",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "atvrentals",
+        "title": "ATV Rentals/Tours",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE",
+            "NL",
+            "BE",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "auctionhouses",
+        "title": "Auction Houses",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "JP",
+            "TW",
+            "PH",
+            "HK",
+            "AR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "audiologist",
+        "title": "Audiologist",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CZ",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "audiovisualequipmentrental",
+        "title": "Audio/Visual Equipment Rental",
+        "parents": [
+            "partyequipmentrentals"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "AT",
+            "ES",
+            "US",
+            "NL",
+            "FR",
+            "DK",
+            "BE",
+            "BR",
+            "NO"
+        ]
+    },
+    {
+        "alias": "australian",
+        "title": "Australian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "austrian",
+        "title": "Austrian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "ES",
+            "DK"
+        ]
+    },
+    {
+        "alias": "authorized_postal_representative",
+        "title": "Authorized Postal Representative",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_whitelist": [
+            "NO",
+            "SE"
+        ]
+    },
+    {
+        "alias": "auto",
+        "title": "Automotive",
+        "parents": []
+    },
+    {
+        "alias": "auto_detailing",
+        "title": "Auto Detailing",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "BR",
+            "ES",
+            "AU"
+        ]
+    },
+    {
+        "alias": "autocustomization",
+        "title": "Auto Customization",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "SG",
+            "ES",
+            "PT",
+            "US",
+            "AR",
+            "MX",
+            "CZ",
+            "CL"
+        ]
+    },
+    {
+        "alias": "autodamageassessment",
+        "title": "Car Inspectors",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "US",
+            "PT",
+            "NL",
+            "DK",
+            "BE",
+            "BR",
+            "NO"
+        ]
+    },
+    {
+        "alias": "autoelectric",
+        "title": "Auto Electric Services",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "AR",
+            "MX",
+            "BR",
+            "CZ",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "autoglass",
+        "title": "Auto Glass Services",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "ES"
+        ]
+    },
+    {
+        "alias": "autoinsurance",
+        "title": "Auto Insurance",
+        "parents": [
+            "insurance"
+        ],
+        "country_blacklist": [
+            "DE",
+            "NZ",
+            "MY",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "FR",
+            "CA",
+            "FI"
+        ]
+    },
+    {
+        "alias": "autoloanproviders",
+        "title": "Auto Loan Providers",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "TR",
+            "SG",
+            "US",
+            "PT",
+            "CA",
+            "CZ",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "autopartssupplies",
+        "title": "Auto Parts & Supplies",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "autorepair",
+        "title": "Auto Repair",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "autosecurity",
+        "title": "Auto Security",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "autoupholstery",
+        "title": "Auto Upholstery",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "auvergnat",
+        "title": "Auvergnat",
+        "parents": [
+            "french"
+        ],
+        "country_whitelist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "aviationservices",
+        "title": "Aviation Services",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "awnings",
+        "title": "Awnings",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "axethrowing",
+        "title": "Axe Throwing",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "GB",
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "ayurveda",
+        "title": "Ayurveda",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "azores",
+        "title": "Azores",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "baby_gear",
+        "title": "Baby Gear & Furniture",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "backflowservices",
+        "title": "Backflow Services",
+        "parents": [
+            "plumbing"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "backshop",
+        "title": "Backshop",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "baden",
+        "title": "Baden",
+        "parents": [
+            "german"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "badminton",
+        "title": "Badminton",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SG",
+            "BR",
+            "NZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "bagels",
+        "title": "Bagels",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "ES",
+            "AU"
+        ]
+    },
+    {
+        "alias": "baguettes",
+        "title": "Baguettes",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "SE",
+            "PT",
+            "MX",
+            "CZ",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "bailbondsmen",
+        "title": "Bail Bondsmen",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT"
+        ]
+    },
+    {
+        "alias": "bakeries",
+        "title": "Bakeries",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "balloonservices",
+        "title": "Balloon Services",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "BR",
+            "AU",
+            "PL"
+        ]
+    },
+    {
+        "alias": "bangladeshi",
+        "title": "Bangladeshi",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "PT",
+            "DK",
+            "MX"
+        ]
+    },
+    {
+        "alias": "bankruptcy",
+        "title": "Bankruptcy Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "banks",
+        "title": "Banks & Credit Unions",
+        "parents": [
+            "financialservices"
+        ]
+    },
+    {
+        "alias": "barbers",
+        "title": "Barbers",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "barcrawl",
+        "title": "Bar Crawl",
+        "parents": [
+            "nightlife"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "US",
+            "AR",
+            "MX",
+            "CZ",
+            "AU",
+            "PL"
+        ]
+    },
+    {
+        "alias": "barreclasses",
+        "title": "Barre Classes",
+        "parents": [
+            "fitness"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "IE",
+            "US",
+            "PT",
+            "NL",
+            "CA",
+            "DK",
+            "BE",
+            "CZ",
+            "AU",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "bars",
+        "title": "Bars",
+        "parents": [
+            "nightlife"
+        ]
+    },
+    {
+        "alias": "bartenders",
+        "title": "Bartenders",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "MY",
+            "CH",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "PL",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "bartendingschools",
+        "title": "Bartending Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "baseballfields",
+        "title": "Baseball Fields",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "basketballcourts",
+        "title": "Basketball Courts",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SE",
+            "NL",
+            "CA",
+            "GB",
+            "BR",
+            "PL",
+            "IE"
+        ]
+    },
+    {
+        "alias": "basque",
+        "title": "Basque",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "PT",
+            "DK",
+            "CZ",
+            "AU",
+            "SG"
+        ]
+    },
+    {
+        "alias": "bathing_area",
+        "title": "Bathing Area",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "JP",
+            "AT",
+            "PT",
+            "DK",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "batterystores",
+        "title": "Battery Stores",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "battingcages",
+        "title": "Batting Cages",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "US",
+            "JP"
+        ]
+    },
+    {
+        "alias": "bavarian",
+        "title": "Bavarian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "bbq",
+        "title": "Barbeque",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "BR",
+            "AU"
+        ]
+    },
+    {
+        "alias": "beachbars",
+        "title": "Beach Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "MY",
+            "GB",
+            "JP",
+            "IE",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "CA",
+            "BE",
+            "CZ",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "beachequipmentrental",
+        "title": "Beach Equipment Rentals",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "beaches",
+        "title": "Beaches",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "beachvolleyball",
+        "title": "Beach Volleyball",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "CH",
+            "TW",
+            "HK",
+            "BE",
+            "MY",
+            "GB",
+            "IE",
+            "US",
+            "PH",
+            "NL",
+            "FR",
+            "CA",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "beautysvc",
+        "title": "Beauty & Spas",
+        "parents": []
+    },
+    {
+        "alias": "bedbreakfast",
+        "title": "Bed & Breakfast",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_blacklist": [
+            "SG"
+        ]
+    },
+    {
+        "alias": "beer_and_wine",
+        "title": "Beer, Wine & Spirits",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "beerbar",
+        "title": "Beer Bar",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "beergarden",
+        "title": "Beer Garden",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CZ",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "beergardens",
+        "title": "Beer Gardens",
+        "parents": [
+            "nightlife"
+        ],
+        "country_whitelist": [
+            "SE",
+            "GB",
+            "JP",
+            "IE",
+            "US",
+            "FR",
+            "DK",
+            "MX",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "beerhall",
+        "title": "Beer Hall",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "beertours",
+        "title": "Beer Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "behavioranalysts",
+        "title": "Behavior Analysts",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "beira",
+        "title": "Beira",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "beisl",
+        "title": "Beisl",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "AT"
+        ]
+    },
+    {
+        "alias": "belgian",
+        "title": "Belgian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "bento",
+        "title": "Bento",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "berrichon",
+        "title": "Berrichon",
+        "parents": [
+            "french"
+        ],
+        "country_whitelist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "bespoke",
+        "title": "Bespoke Clothing",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "JP",
+            "AR",
+            "FI",
+            "MX",
+            "BR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "bettingcenters",
+        "title": "Betting Centers",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "US",
+            "FR",
+            "CA",
+            "NZ",
+            "SG",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "beverage_stores",
+        "title": "Beverage Store",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "CH",
+            "AT",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "BE",
+            "AU",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "bicyclepaths",
+        "title": "Bicycle Paths",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "MY",
+            "CH",
+            "AT",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "FR",
+            "CA",
+            "IT"
+        ]
+    },
+    {
+        "alias": "bicycles",
+        "title": "Bicycles",
+        "parents": [],
+        "country_whitelist": [
+            "PT",
+            "CZ",
+            "PL",
+            "DK"
+        ]
+    },
+    {
+        "alias": "bike_repair_maintenance",
+        "title": "Bike Repair/Maintenance",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "bikeassociations",
+        "title": "Bike Associations",
+        "parents": [
+            "bicycles"
+        ],
+        "country_whitelist": [
+            "DK",
+            "PT"
+        ]
+    },
+    {
+        "alias": "bikeparking",
+        "title": "Bike Parking",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "bikerentals",
+        "title": "Bike Rentals",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "bikerepair",
+        "title": "Bike Repair",
+        "parents": [
+            "bicycles"
+        ],
+        "country_whitelist": [
+            "DK",
+            "PT"
+        ]
+    },
+    {
+        "alias": "bikes",
+        "title": "Bikes",
+        "parents": [
+            "sportgoods"
+        ]
+    },
+    {
+        "alias": "bikesharing",
+        "title": "Bike Sharing",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "bikeshop",
+        "title": "Bike Shop",
+        "parents": [
+            "bicycles"
+        ],
+        "country_whitelist": [
+            "DK",
+            "PT"
+        ]
+    },
+    {
+        "alias": "biketours",
+        "title": "Bike tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "billingservices",
+        "title": "Billing Services",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE"
+        ]
+    },
+    {
+        "alias": "bingo",
+        "title": "Bingo Halls",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "SE",
+            "NZ",
+            "GB",
+            "CL",
+            "IE",
+            "ES",
+            "US",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "AU",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "birdshops",
+        "title": "Bird Shops",
+        "parents": [
+            "petstore"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "SG",
+            "ES",
+            "US",
+            "NL",
+            "DK",
+            "BE",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "bistros",
+        "title": "Bistros",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "blacksea",
+        "title": "Black Sea",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "blinds",
+        "title": "Shades & Blinds",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "blooddonation",
+        "title": "Blood & Plasma Donation Centers",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "MY",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "PH",
+            "HK",
+            "NL",
+            "CA",
+            "BE",
+            "FI"
+        ]
+    },
+    {
+        "alias": "blowfish",
+        "title": "Blowfish",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "blowoutservices",
+        "title": "Blow Dry/Out Services",
+        "parents": [
+            "hair"
+        ],
+        "country_whitelist": [
+            "TR",
+            "GB",
+            "IE",
+            "US",
+            "PT",
+            "FR",
+            "CA",
+            "DK",
+            "CZ",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "boatcharters",
+        "title": "Boat Charters",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "boatdealers",
+        "title": "Boat Dealers",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "CH",
+            "JP",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "FR",
+            "FI",
+            "BR",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "boating",
+        "title": "Boating",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "boatpartsandsupplies",
+        "title": "Boat Parts & Supplies",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "boatrepair",
+        "title": "Boat Repair",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "boattours",
+        "title": "Boat Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "bobsledding",
+        "title": "Bobsledding",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "bocceball",
+        "title": "Bocce Ball",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "bodycontouring",
+        "title": "Body Contouring",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "FR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "bodyshops",
+        "title": "Body Shops",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "bookbinding",
+        "title": "Bookbinding",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "bookkeepers",
+        "title": "Bookkeepers",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "MY",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "NL",
+            "CA",
+            "BE",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "bookstores",
+        "title": "Bookstores",
+        "parents": [
+            "media"
+        ]
+    },
+    {
+        "alias": "bootcamps",
+        "title": "Boot Camps",
+        "parents": [
+            "fitness"
+        ],
+        "country_whitelist": [
+            "SE",
+            "NZ",
+            "ES",
+            "PT",
+            "US",
+            "DK",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "boudoirphotography",
+        "title": "Boudoir Photography",
+        "parents": [
+            "photographers"
+        ],
+        "country_whitelist": [
+            "SE",
+            "CA",
+            "US",
+            "DE"
+        ]
+    },
+    {
+        "alias": "bouncehouserentals",
+        "title": "Bounce House Rentals",
+        "parents": [
+            "partyequipmentrentals"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE",
+            "DE",
+            "CA",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "bourguignon",
+        "title": "Bourguignon",
+        "parents": [
+            "french"
+        ],
+        "country_whitelist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "bowling",
+        "title": "Bowling",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "boxing",
+        "title": "Boxing",
+        "parents": [
+            "fitness"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "SE",
+            "PL",
+            "AU",
+            "SG",
+            "FI"
+        ]
+    },
+    {
+        "alias": "brasseries",
+        "title": "Brasseries",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR"
+        ]
+    },
+    {
+        "alias": "brazilian",
+        "title": "Brazilian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "brazilianempanadas",
+        "title": "Brazilian Empanadas",
+        "parents": [
+            "brazilian"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "brazilianjiujitsu",
+        "title": "Brazilian Jiu-jitsu",
+        "parents": [
+            "martialarts"
+        ]
+    },
+    {
+        "alias": "breakfast_brunch",
+        "title": "Breakfast & Brunch",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "breweries",
+        "title": "Breweries",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "brewingsupplies",
+        "title": "Brewing Supplies",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "AR",
+            "JP",
+            "CL",
+            "HK"
+        ]
+    },
+    {
+        "alias": "brewpubs",
+        "title": "Brewpubs",
+        "parents": [
+            "breweries"
+        ],
+        "country_blacklist": [
+            "ES",
+            "FR",
+            "AR",
+            "MX",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "bridal",
+        "title": "Bridal",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "british",
+        "title": "British",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "bubblesoccer",
+        "title": "Bubble Soccer",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "bubbletea",
+        "title": "Bubble Tea",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "AR",
+            "CH",
+            "MX",
+            "AT"
+        ]
+    },
+    {
+        "alias": "buddhist_temples",
+        "title": "Buddhist Temples",
+        "parents": [
+            "religiousorgs"
+        ]
+    },
+    {
+        "alias": "buffets",
+        "title": "Buffets",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "buildingsupplies",
+        "title": "Building Supplies",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "bulgarian",
+        "title": "Bulgarian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "SG",
+            "NL",
+            "CA",
+            "DK",
+            "BR",
+            "NO"
+        ]
+    },
+    {
+        "alias": "bulkbilling",
+        "title": "Bulk Billing",
+        "parents": [
+            "medcenters"
+        ],
+        "country_whitelist": [
+            "AU"
+        ]
+    },
+    {
+        "alias": "bungeejumping",
+        "title": "Bungee Jumping",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "burgers",
+        "title": "Burgers",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "burmese",
+        "title": "Burmese",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "PT",
+            "DK",
+            "CZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "buses",
+        "title": "Buses",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "businessconsulting",
+        "title": "Business Consulting",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "TW",
+            "TR",
+            "HK",
+            "CZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "businessfinancing",
+        "title": "Business Financing",
+        "parents": [
+            "financialservices"
+        ]
+    },
+    {
+        "alias": "businesslawyers",
+        "title": "Business Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_whitelist": [
+            "GB",
+            "IE",
+            "US",
+            "PT",
+            "CA",
+            "DK",
+            "BR",
+            "CZ",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "busrental",
+        "title": "Bus Rental",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "busstations",
+        "title": "Bus Stations",
+        "parents": [
+            "transport"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "bustours",
+        "title": "Bus Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "butcher",
+        "title": "Butcher",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "c_and_mh",
+        "title": "Counseling & Mental Health",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "cabaret",
+        "title": "Cabaret",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "cabinetry",
+        "title": "Cabinetry",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "cablecars",
+        "title": "Cable Cars",
+        "parents": [
+            "transport"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "AT",
+            "US",
+            "PT",
+            "FR",
+            "BR",
+            "CZ",
+            "IT"
+        ]
+    },
+    {
+        "alias": "cafes",
+        "title": "Cafes",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "ES",
+            "FI"
+        ]
+    },
+    {
+        "alias": "cafeteria",
+        "title": "Cafeteria",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "SE",
+            "FR",
+            "CA",
+            "NZ",
+            "BR",
+            "SG",
+            "IE"
+        ]
+    },
+    {
+        "alias": "cajun",
+        "title": "Cajun/Creole",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "SG",
+            "PT",
+            "ES",
+            "AU"
+        ]
+    },
+    {
+        "alias": "cakeshop",
+        "title": "Patisserie/Cake Shop",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "calabrian",
+        "title": "Calabrian",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "US",
+            "IT"
+        ]
+    },
+    {
+        "alias": "calligraphy",
+        "title": "Calligraphy",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "TR",
+            "ES",
+            "US",
+            "NL",
+            "BE",
+            "BR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "cambodian",
+        "title": "Cambodian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "PT",
+            "DK",
+            "CZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "campgrounds",
+        "title": "Campgrounds",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "candlestores",
+        "title": "Candle Stores",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "candy",
+        "title": "Candy Stores",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "cannabis_clinics",
+        "title": "Cannabis Clinics",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "TR",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "CA",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "cannabiscollective",
+        "title": "Cannabis Collective",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "cannabisdispensaries",
+        "title": "Cannabis Dispensaries",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "cannabisreferrals",
+        "title": "Medical Cannabis Referrals",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "cannabistours",
+        "title": "Cannabis Tours",
+        "parents": [
+            "cannabis_clinics"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "canteen",
+        "title": "Canteen",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "JP",
+            "AT",
+            "NL",
+            "DK",
+            "BE",
+            "CZ",
+            "PL",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "cantonese",
+        "title": "Cantonese",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "JP",
+            "SG",
+            "TW",
+            "HK",
+            "BE",
+            "SE",
+            "MY",
+            "GB",
+            "US",
+            "NL",
+            "FR",
+            "AR",
+            "CA",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "car_dealers",
+        "title": "Car Dealers",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "carauctions",
+        "title": "Car Auctions",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "MY",
+            "SG"
+        ]
+    },
+    {
+        "alias": "carbrokers",
+        "title": "Car Brokers",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "AR",
+            "NZ",
+            "US",
+            "AU"
+        ]
+    },
+    {
+        "alias": "carbuyers",
+        "title": "Car Buyers",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "BR",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "cardioclasses",
+        "title": "Cardio Classes",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "cardiology",
+        "title": "Cardiologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "careercounseling",
+        "title": "Career Counseling",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "caribbean",
+        "title": "Caribbean",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "PT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "caricatures",
+        "title": "Caricatures",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "SE",
+            "SG",
+            "ES",
+            "US",
+            "DK",
+            "BR",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "carousels",
+        "title": "Carousels",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "carpenters",
+        "title": "Carpenters",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "carpet_cleaning",
+        "title": "Carpet Cleaning",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "carpetdyeing",
+        "title": "Carpet Dyeing",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "carpeting",
+        "title": "Carpeting",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "carpetinstallation",
+        "title": "Carpet Installation",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "carrental",
+        "title": "Car Rental",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "carshares",
+        "title": "Car Share Services",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "JP",
+            "SG",
+            "TW",
+            "PT",
+            "HK",
+            "NL",
+            "BE",
+            "BR",
+            "FI"
+        ]
+    },
+    {
+        "alias": "carwash",
+        "title": "Car Wash",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "carwindowtinting",
+        "title": "Car Window Tinting",
+        "parents": [
+            "autoglass"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "ES",
+            "NL",
+            "CA",
+            "BE",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "casinos",
+        "title": "Casinos",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "JP",
+            "HK"
+        ]
+    },
+    {
+        "alias": "castles",
+        "title": "Castles",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "GB",
+            "JP",
+            "AT",
+            "ES",
+            "PT",
+            "FR",
+            "DK",
+            "BE",
+            "CZ",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "catalan",
+        "title": "Catalan",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "ES",
+            "PT",
+            "US",
+            "FR",
+            "AR",
+            "MX",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "catering",
+        "title": "Caterers",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "cellphoneaccessories",
+        "title": "Mobile Phone Accessories",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "PH",
+            "MY",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "centralbrazilian",
+        "title": "Central Brazilian",
+        "parents": [
+            "brazilian"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "ceremonialclothing",
+        "title": "Ceremonial Clothing",
+        "parents": [
+            "fashion"
+        ],
+        "country_blacklist": [
+            "DE",
+            "FR",
+            "CH",
+            "JP",
+            "AT"
+        ]
+    },
+    {
+        "alias": "challengecourses",
+        "title": "Challenge Courses",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "NZ",
+            "CH",
+            "SG",
+            "AT",
+            "US",
+            "HK",
+            "FR",
+            "CA",
+            "DK",
+            "CZ",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "champagne_bars",
+        "title": "Champagne Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "AU"
+        ]
+    },
+    {
+        "alias": "cheekufta",
+        "title": "Chee Kufta",
+        "parents": [
+            "turkish"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE"
+        ]
+    },
+    {
+        "alias": "cheerleading",
+        "title": "Cheerleading",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE",
+            "DE",
+            "CA",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "cheese",
+        "title": "Cheese Shops",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "cheesesteaks",
+        "title": "Cheesesteaks",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US",
+            "NL",
+            "CA",
+            "GB",
+            "AU",
+            "PL",
+            "IE"
+        ]
+    },
+    {
+        "alias": "cheesetastingclasses",
+        "title": "Cheese Tasting Classes",
+        "parents": [
+            "tastingclasses"
+        ]
+    },
+    {
+        "alias": "chicken_wings",
+        "title": "Chicken Wings",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "CH",
+            "CL",
+            "JP",
+            "ES",
+            "PT",
+            "NL",
+            "FR",
+            "DK",
+            "BE",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "chickenshop",
+        "title": "Chicken Shop",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "childbirthedu",
+        "title": "Childbirth Education",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "SE",
+            "GB",
+            "IE",
+            "ES",
+            "US",
+            "FR",
+            "DK",
+            "BR",
+            "AU",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "childcare",
+        "title": "Child Care & Day Care",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "childcloth",
+        "title": "Children's Clothing",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "childproofing",
+        "title": "Childproofing",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "BR",
+            "US",
+            "PT"
+        ]
+    },
+    {
+        "alias": "childrensmuseums",
+        "title": "Children's Museums",
+        "parents": [
+            "museums"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "chilean",
+        "title": "Chilean",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "FI",
+            "BR",
+            "FR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "chimneycakes",
+        "title": "Chimney Cakes",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "FR",
+            "US",
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "chimneysweeps",
+        "title": "Chimney Sweeps",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "chinese",
+        "title": "Chinese",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "chinesebazaar",
+        "title": "Chinese Bazaar",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT"
+        ]
+    },
+    {
+        "alias": "chinesemartialarts",
+        "title": "Chinese Martial Arts",
+        "parents": [
+            "martialarts"
+        ]
+    },
+    {
+        "alias": "chiropractors",
+        "title": "Chiropractors",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "chocolate",
+        "title": "Chocolatiers & Shops",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "choirs",
+        "title": "Choirs",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "SG",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "BR",
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "christmastrees",
+        "title": "Christmas Trees",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "churches",
+        "title": "Churches",
+        "parents": [
+            "religiousorgs"
+        ]
+    },
+    {
+        "alias": "churros",
+        "title": "Churros",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "AR",
+            "MX",
+            "BR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "cideries",
+        "title": "Cideries",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "TR",
+            "JP",
+            "NL",
+            "FR",
+            "DK",
+            "BE",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "cigarbars",
+        "title": "Cigar Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "circuittraininggyms",
+        "title": "Circuit Training Gyms",
+        "parents": [
+            "gyms"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "circusschools",
+        "title": "Circus Schools",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "FR",
+            "AR",
+            "FI",
+            "MX",
+            "BR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "civiccenter",
+        "title": "Civic Center",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "climbing",
+        "title": "Climbing",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "clockrepair",
+        "title": "Clock Repair",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "AR",
+            "MX",
+            "JP",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "clothingrental",
+        "title": "Clothing Rental",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "clowns",
+        "title": "Clowns",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "CZ",
+            "PL",
+            "SG",
+            "FI"
+        ]
+    },
+    {
+        "alias": "clubcrawl",
+        "title": "Club Crawl",
+        "parents": [
+            "nightlife"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "cocktailbars",
+        "title": "Cocktail Bars",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "coffee",
+        "title": "Coffee & Tea",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "coffeeroasteries",
+        "title": "Coffee Roasteries",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "coffeeshops",
+        "title": "Coffeeshops",
+        "parents": [
+            "nightlife"
+        ],
+        "country_whitelist": [
+            "NL",
+            "PT"
+        ]
+    },
+    {
+        "alias": "coffeeteasupplies",
+        "title": "Coffee & Tea Supplies",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "MY",
+            "CL",
+            "ES",
+            "PH",
+            "PT",
+            "US",
+            "AR",
+            "MX",
+            "BR",
+            "CZ",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "collegecounseling",
+        "title": "College Counseling",
+        "parents": [
+            "education"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT"
+        ]
+    },
+    {
+        "alias": "collegeuniv",
+        "title": "Colleges & Universities",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "colombian",
+        "title": "Colombian",
+        "parents": [
+            "latin"
+        ],
+        "country_whitelist": [
+            "CL",
+            "ES",
+            "US",
+            "FR",
+            "AR",
+            "CA",
+            "MX",
+            "BE",
+            "FI"
+        ]
+    },
+    {
+        "alias": "colonics",
+        "title": "Colonics",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "CA",
+            "DK",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "comedyclubs",
+        "title": "Comedy Clubs",
+        "parents": [
+            "nightlife"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "comfortfood",
+        "title": "Comfort Food",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US",
+            "AR",
+            "CA",
+            "MX",
+            "CL",
+            "JP",
+            "FI"
+        ]
+    },
+    {
+        "alias": "comicbooks",
+        "title": "Comic Books",
+        "parents": [
+            "media"
+        ]
+    },
+    {
+        "alias": "commercialrealestate",
+        "title": "Commercial Real Estate",
+        "parents": [
+            "realestate"
+        ],
+        "country_whitelist": [
+            "DE",
+            "US",
+            "PT",
+            "NL",
+            "CA",
+            "DK",
+            "BE",
+            "BR",
+            "CZ",
+            "AU",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "commissionedartists",
+        "title": "Commissioned Artists",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "communitybookbox",
+        "title": "Community Book Box",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "MY",
+            "JP",
+            "ES",
+            "PH",
+            "FR",
+            "AR",
+            "MX",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "communitycenters",
+        "title": "Community Centers",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_whitelist": [
+            "SE",
+            "GB",
+            "IE",
+            "US",
+            "PT",
+            "CA",
+            "DK",
+            "BR",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "communitygardens",
+        "title": "Community Gardens",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "SG",
+            "ES",
+            "PT",
+            "US",
+            "FR",
+            "DK",
+            "BR",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "computers",
+        "title": "Computers",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "concept_shops",
+        "title": "Concept Shops",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "NZ",
+            "JP",
+            "SG",
+            "ES",
+            "US",
+            "HK",
+            "AR",
+            "CA",
+            "BR",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "conciergemedicine",
+        "title": "Concierge Medicine",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "condominiums",
+        "title": "Condominiums",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "congee",
+        "title": "Congee",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "MY",
+            "HK"
+        ]
+    },
+    {
+        "alias": "contractlaw",
+        "title": "Contract Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "contractors",
+        "title": "Contractors",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "convenience",
+        "title": "Convenience Stores",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "conveyorsushi",
+        "title": "Conveyor Belt Sushi",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "JP",
+            "SG",
+            "AT",
+            "TW",
+            "US",
+            "HK",
+            "NL",
+            "BE",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "cookingclasses",
+        "title": "Cooking Classes",
+        "parents": [
+            "artsandcrafts"
+        ]
+    },
+    {
+        "alias": "cookingschools",
+        "title": "Cooking Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "copyshops",
+        "title": "Printing Services",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "corsican",
+        "title": "Corsican",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "BE",
+            "FR"
+        ]
+    },
+    {
+        "alias": "cosmeticdentists",
+        "title": "Cosmetic Dentists",
+        "parents": [
+            "dentists"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "cosmetics",
+        "title": "Cosmetics & Beauty Supply",
+        "parents": [
+            "shopping",
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "cosmeticsurgeons",
+        "title": "Cosmetic Surgeons",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "cosmetology_schools",
+        "title": "Cosmetology Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "costumes",
+        "title": "Costumes",
+        "parents": [
+            "artsandcrafts"
+        ]
+    },
+    {
+        "alias": "countertopinstall",
+        "title": "Countertop Installation",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "DE",
+            "FR",
+            "CH",
+            "CZ",
+            "IT",
+            "AT"
+        ]
+    },
+    {
+        "alias": "countryclubs",
+        "title": "Country Clubs",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "JP",
+            "SG",
+            "TW",
+            "ES",
+            "US",
+            "HK",
+            "AR",
+            "MX",
+            "BR",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "countrydancehalls",
+        "title": "Country Dance Halls",
+        "parents": [
+            "nightlife"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE"
+        ]
+    },
+    {
+        "alias": "couriers",
+        "title": "Couriers & Delivery Services",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "courthouses",
+        "title": "Courthouses",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "JP",
+            "SG",
+            "TW",
+            "ES",
+            "HK",
+            "MX",
+            "CL",
+            "MY",
+            "GB",
+            "IE",
+            "PH",
+            "AR",
+            "CA",
+            "FI"
+        ]
+    },
+    {
+        "alias": "courtreporters",
+        "title": "Court Reporters",
+        "parents": [
+            "legalservices"
+        ],
+        "country_whitelist": [
+            "NL",
+            "BE",
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "cprclasses",
+        "title": "CPR Classes",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "SE",
+            "PT",
+            "US",
+            "AU"
+        ]
+    },
+    {
+        "alias": "craneservices",
+        "title": "Crane Services",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "JP",
+            "TW",
+            "PH",
+            "HK",
+            "FR",
+            "FI"
+        ]
+    },
+    {
+        "alias": "cremationservices",
+        "title": "Cremation Services",
+        "parents": [
+            "funeralservices"
+        ],
+        "country_blacklist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "creperies",
+        "title": "Creperies",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "criminaldefense",
+        "title": "Criminal Defense Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "cryotherapy",
+        "title": "Cryotherapy",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US",
+            "IT"
+        ]
+    },
+    {
+        "alias": "csa",
+        "title": "CSA",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "US",
+            "DE",
+            "FR",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "cuban",
+        "title": "Cuban",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "SG",
+            "TR",
+            "DK"
+        ]
+    },
+    {
+        "alias": "cucinacampana",
+        "title": "Cucina campana",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "culturalcenter",
+        "title": "Cultural Center",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "TR",
+            "CA",
+            "NZ",
+            "IE"
+        ]
+    },
+    {
+        "alias": "cupcakes",
+        "title": "Cupcakes",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "CA",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "currencyexchange",
+        "title": "Currency Exchange",
+        "parents": [
+            "financialservices"
+        ]
+    },
+    {
+        "alias": "currysausage",
+        "title": "Curry Sausage",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "customcakes",
+        "title": "Custom Cakes",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "FR",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "custommerchandise",
+        "title": "Customized Merchandise",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "customsbrokers",
+        "title": "Customs Brokers",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "cyclingclasses",
+        "title": "Cycling Classes",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "PT",
+            "AR",
+            "CA",
+            "NZ",
+            "MX",
+            "BR",
+            "IE"
+        ]
+    },
+    {
+        "alias": "cypriot",
+        "title": "Cypriot",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "czech",
+        "title": "Czech",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "GB",
+            "IE",
+            "US",
+            "FR",
+            "CA",
+            "DK",
+            "BE",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "czechslovakian",
+        "title": "Czech/Slovakian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "MX",
+            "AR",
+            "PT"
+        ]
+    },
+    {
+        "alias": "dagashi",
+        "title": "Dagashi",
+        "parents": [
+            "gourmet"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "damagerestoration",
+        "title": "Damage Restoration",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "TR",
+            "US",
+            "PT",
+            "CA",
+            "NZ",
+            "AU",
+            "SG"
+        ]
+    },
+    {
+        "alias": "dance_schools",
+        "title": "Dance Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "danceclubs",
+        "title": "Dance Clubs",
+        "parents": [
+            "nightlife"
+        ]
+    },
+    {
+        "alias": "dancerestaurants",
+        "title": "Dance Restaurants",
+        "parents": [
+            "nightlife"
+        ],
+        "country_whitelist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "dancestudio",
+        "title": "Dance Studios",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "dancewear",
+        "title": "Dance Wear",
+        "parents": [
+            "sportswear"
+        ]
+    },
+    {
+        "alias": "danish",
+        "title": "Danish",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "FR",
+            "NO",
+            "DK",
+            "SE"
+        ]
+    },
+    {
+        "alias": "datarecovery",
+        "title": "Data Recovery",
+        "parents": [
+            "itservices"
+        ],
+        "country_blacklist": [
+            "TW",
+            "PH",
+            "HK",
+            "NL",
+            "MY",
+            "JP",
+            "FI"
+        ]
+    },
+    {
+        "alias": "daycamps",
+        "title": "Day Camps",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "debtrelief",
+        "title": "Debt Relief Services",
+        "parents": [
+            "financialservices"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "decksrailing",
+        "title": "Decks & Railing",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "delicatessen",
+        "title": "Delicatessen",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "delis",
+        "title": "Delis",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "PT",
+            "SE",
+            "NL",
+            "FR",
+            "BE",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "demolitionservices",
+        "title": "Demolition Services",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "DK",
+            "BE",
+            "BR",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "dentalhygeiniststorefront",
+        "title": "Storefront Clinics",
+        "parents": [
+            "dentalhygienists"
+        ],
+        "country_whitelist": [
+            "CA"
+        ]
+    },
+    {
+        "alias": "dentalhygienists",
+        "title": "Dental Hygienists",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US",
+            "DE",
+            "PT",
+            "NL",
+            "CA",
+            "DK",
+            "NO"
+        ]
+    },
+    {
+        "alias": "dentalhygienistsmobile",
+        "title": "Mobile Clinics",
+        "parents": [
+            "dentalhygienists"
+        ],
+        "country_whitelist": [
+            "CA"
+        ]
+    },
+    {
+        "alias": "dentists",
+        "title": "Dentists",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "departmentsofmotorvehicles",
+        "title": "Departments of Motor Vehicles",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_blacklist": [
+            "BE",
+            "FR"
+        ]
+    },
+    {
+        "alias": "deptstores",
+        "title": "Department Stores",
+        "parents": [
+            "shopping",
+            "fashion"
+        ]
+    },
+    {
+        "alias": "dermatology",
+        "title": "Dermatologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "desserts",
+        "title": "Desserts",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "diagnosticimaging",
+        "title": "Diagnostic Imaging",
+        "parents": [
+            "diagnosticservices"
+        ],
+        "country_whitelist": [
+            "GB",
+            "IE",
+            "ES",
+            "PT",
+            "US",
+            "FR",
+            "AR",
+            "CA",
+            "MX",
+            "BR",
+            "AU",
+            "CL"
+        ]
+    },
+    {
+        "alias": "diagnosticservices",
+        "title": "Diagnostic Services",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "dialysisclinics",
+        "title": "Dialysis Clinics",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "TR",
+            "ES",
+            "PT",
+            "US",
+            "AR",
+            "MX",
+            "BR",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "dietitians",
+        "title": "Dietitians",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "digitizingservices",
+        "title": "Digitizing Services",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "US",
+            "BR",
+            "DK",
+            "NO"
+        ]
+    },
+    {
+        "alias": "dimsum",
+        "title": "Dim Sum",
+        "parents": [
+            "chinese"
+        ],
+        "country_blacklist": [
+            "TR",
+            "BR",
+            "PT"
+        ]
+    },
+    {
+        "alias": "diners",
+        "title": "Diners",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "SE",
+            "FI",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "dinnertheater",
+        "title": "Dinner Theater",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "NL",
+            "FR",
+            "BE",
+            "JP",
+            "IT"
+        ]
+    },
+    {
+        "alias": "disabilitylaw",
+        "title": "Disability Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "discgolf",
+        "title": "Disc Golf",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SG",
+            "DK",
+            "AU"
+        ]
+    },
+    {
+        "alias": "discountstore",
+        "title": "Discount Store",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "distilleries",
+        "title": "Distilleries",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "divebars",
+        "title": "Dive Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "NL",
+            "FR",
+            "BE",
+            "CZ",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "diveshops",
+        "title": "Dive Shops",
+        "parents": [
+            "sportgoods"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "AT",
+            "ES",
+            "US",
+            "AR",
+            "MX",
+            "BR",
+            "AU",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "diving",
+        "title": "Diving",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "divorce",
+        "title": "Divorce & Family Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "diyautoshop",
+        "title": "DIY Auto Shop",
+        "parents": [
+            "autorepair"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT",
+            "DE",
+            "CH",
+            "AU",
+            "AT"
+        ]
+    },
+    {
+        "alias": "diyfood",
+        "title": "Do-It-Yourself Food",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "DE",
+            "SE",
+            "NZ",
+            "CH",
+            "CL",
+            "AT",
+            "ES",
+            "FR",
+            "MX",
+            "CZ",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "djs",
+        "title": "DJs",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "dog_parks",
+        "title": "Dog Parks",
+        "parents": [
+            "parks"
+        ]
+    },
+    {
+        "alias": "dogwalkers",
+        "title": "Dog Walkers",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "dolmusstation",
+        "title": "Dolmus Station",
+        "parents": [
+            "transport"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "dominican",
+        "title": "Dominican",
+        "parents": [
+            "caribbean"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "donairs",
+        "title": "Donairs",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "TR",
+            "FR",
+            "CA",
+            "DK",
+            "BE",
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "donationcenter",
+        "title": "Donation Center",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "ES",
+            "US",
+            "NL",
+            "DK",
+            "BE",
+            "BR",
+            "NO"
+        ]
+    },
+    {
+        "alias": "donburi",
+        "title": "Donburi",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP",
+            "HK"
+        ]
+    },
+    {
+        "alias": "donuts",
+        "title": "Donuts",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "ES"
+        ]
+    },
+    {
+        "alias": "doorsales",
+        "title": "Door Sales/Installation",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "JP",
+            "TW",
+            "ES",
+            "HK",
+            "DK",
+            "MX",
+            "CL",
+            "SE",
+            "MY",
+            "IE",
+            "PH",
+            "FR",
+            "AR",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "doulas",
+        "title": "Doulas",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT",
+            "FR",
+            "CA",
+            "BE",
+            "CZ",
+            "IT"
+        ]
+    },
+    {
+        "alias": "dramaschools",
+        "title": "Drama Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "driedfruit",
+        "title": "Dried Fruit",
+        "parents": [
+            "gourmet"
+        ],
+        "country_whitelist": [
+            "TR",
+            "SE",
+            "JP",
+            "TW",
+            "ES",
+            "HK",
+            "AR",
+            "MX",
+            "BR",
+            "CZ",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "driveintheater",
+        "title": "Drive-In Theater",
+        "parents": [
+            "movietheaters"
+        ],
+        "country_blacklist": [
+            "FR",
+            "AR",
+            "MX",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "drivethrubars",
+        "title": "Drive-Thru Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "driving_schools",
+        "title": "Driving Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "drones",
+        "title": "Drones",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "drugstores",
+        "title": "Drugstores",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "FR",
+            "AR",
+            "DK",
+            "MX",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "dryclean",
+        "title": "Dry Cleaning",
+        "parents": [
+            "laundryservices"
+        ]
+    },
+    {
+        "alias": "drywall",
+        "title": "Drywall Installation & Repair",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "JP",
+            "HK"
+        ]
+    },
+    {
+        "alias": "duilawyers",
+        "title": "DUI Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US",
+            "DE"
+        ]
+    },
+    {
+        "alias": "duischools",
+        "title": "DUI Schools",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "dumplings",
+        "title": "Dumplings",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "dumpsterrental",
+        "title": "Dumpster Rental",
+        "parents": [
+            "junkremovalandhauling"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "US",
+            "HK",
+            "CA",
+            "DK",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "duplicationservices",
+        "title": "Duplication Services",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "dutyfreeshops",
+        "title": "Duty-Free Shops",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "earnosethroat",
+        "title": "Ear Nose & Throat",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "eastern_european",
+        "title": "Eastern European",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "FR",
+            "DK",
+            "CZ",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "easterngerman",
+        "title": "Eastern German",
+        "parents": [
+            "german"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "easternmexican",
+        "title": "Eastern Mexican",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "eatertainment",
+        "title": "Eatertainment",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "US",
+            "DE",
+            "NL",
+            "CH",
+            "BE",
+            "BR",
+            "AT"
+        ]
+    },
+    {
+        "alias": "editorialservices",
+        "title": "Editorial Services",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "DE",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "FR",
+            "AR",
+            "DK",
+            "MX",
+            "BE",
+            "BR",
+            "NO",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "education",
+        "title": "Education",
+        "parents": []
+    },
+    {
+        "alias": "educationservices",
+        "title": "Educational Services",
+        "parents": [
+            "education"
+        ],
+        "country_blacklist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "egyptian",
+        "title": "Egyptian",
+        "parents": [
+            "mideastern"
+        ],
+        "country_whitelist": [
+            "US",
+            "FR",
+            "CA",
+            "BE",
+            "IT"
+        ]
+    },
+    {
+        "alias": "eldercareplanning",
+        "title": "Elder Care Planning",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "electricians",
+        "title": "Electricians",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "electricitysuppliers",
+        "title": "Electricity Suppliers",
+        "parents": [
+            "utilities"
+        ]
+    },
+    {
+        "alias": "electronics",
+        "title": "Electronics",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "electronicsrepair",
+        "title": "Electronics Repair",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "elementaryschools",
+        "title": "Elementary Schools",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "eltern_cafes",
+        "title": "Parent Cafes",
+        "parents": [
+            "restaurants",
+            "food"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "embassy",
+        "title": "Embassy",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_blacklist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "embroideryandcrochet",
+        "title": "Embroidery & Crochet",
+        "parents": [
+            "artsandcrafts"
+        ]
+    },
+    {
+        "alias": "emergencymedicine",
+        "title": "Emergency Medicine",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "emergencypethospital",
+        "title": "Emergency Pet Hospital",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "emergencyrooms",
+        "title": "Emergency Rooms",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "emilian",
+        "title": "Emilian",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "empanadas",
+        "title": "Empanadas",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "US",
+            "AR",
+            "ES",
+            "CL"
+        ]
+    },
+    {
+        "alias": "employmentagencies",
+        "title": "Employment Agencies",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "employmentlawyers",
+        "title": "Employment Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "emstraining",
+        "title": "EMS Training",
+        "parents": [
+            "fitness"
+        ],
+        "country_whitelist": [
+            "ES",
+            "SE",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "endocrinologists",
+        "title": "Endocrinologists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "SE",
+            "NZ",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "TW",
+            "HK",
+            "CA",
+            "AU",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "endodontists",
+        "title": "Endodontists",
+        "parents": [
+            "dentists"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "engraving",
+        "title": "Engraving",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "entertainmentlaw",
+        "title": "Entertainment Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "enviroabatement",
+        "title": "Environmental Abatement",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "environmentaltesting",
+        "title": "Environmental Testing",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "NL",
+            "CA",
+            "DK",
+            "BE",
+            "AU",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "eroticmassage",
+        "title": "Erotic Massage",
+        "parents": [
+            "beautysvc"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "MY",
+            "JP",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "DK",
+            "FI",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "escapegames",
+        "title": "Escape Games",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "estateliquidation",
+        "title": "Estate Liquidation",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "estatephotography",
+        "title": "Real Estate Photography",
+        "parents": [
+            "realestatesvcs"
+        ],
+        "country_blacklist": [
+            "JP",
+            "IT"
+        ]
+    },
+    {
+        "alias": "estateplanning",
+        "title": "Estate Planning Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_blacklist": [
+            "NO",
+            "SE"
+        ]
+    },
+    {
+        "alias": "estheticians",
+        "title": "Estheticians",
+        "parents": [
+            "skincare"
+        ]
+    },
+    {
+        "alias": "ethicgrocery",
+        "title": "Ethical Grocery",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "MY",
+            "CH",
+            "JP",
+            "AT",
+            "US",
+            "PH",
+            "NL",
+            "FR",
+            "BE",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "ethiopian",
+        "title": "Ethiopian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "MX",
+            "TR",
+            "SG",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "evchargingstations",
+        "title": "EV Charging Stations",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "eventphotography",
+        "title": "Event Photography",
+        "parents": [
+            "photographers"
+        ]
+    },
+    {
+        "alias": "eventplanning",
+        "title": "Party & Event Planning",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "eventservices",
+        "title": "Event Planning & Services",
+        "parents": []
+    },
+    {
+        "alias": "excavationservices",
+        "title": "Excavation Services",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "experiences",
+        "title": "Experiences",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "PT",
+            "DE",
+            "SE",
+            "DK",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "eyebrowservices",
+        "title": "Eyebrow Services",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "eyelashservice",
+        "title": "Eyelash Service",
+        "parents": [
+            "beautysvc"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "fabricstores",
+        "title": "Fabric Stores",
+        "parents": [
+            "artsandcrafts"
+        ]
+    },
+    {
+        "alias": "facepainting",
+        "title": "Face Painting",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "JP",
+            "SG",
+            "TW",
+            "ES",
+            "HK",
+            "MX",
+            "CL",
+            "SE",
+            "MY",
+            "PH",
+            "FR",
+            "AR",
+            "PL",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "fado_houses",
+        "title": "Fado Houses",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "falafel",
+        "title": "Falafel",
+        "parents": [
+            "mediterranean"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "PT"
+        ]
+    },
+    {
+        "alias": "familydr",
+        "title": "Family Practice",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "farmequipmentrepair",
+        "title": "Farm Equipment Repair",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "farmersmarket",
+        "title": "Farmers Market",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "farmingequipment",
+        "title": "Farming Equipment",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "farms",
+        "title": "Farms",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "farriers",
+        "title": "Farriers",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "fashion",
+        "title": "Fashion",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "fasil",
+        "title": "Fasil Music",
+        "parents": [
+            "nightlife"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "fencesgates",
+        "title": "Fences & Gates",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "fencing",
+        "title": "Fencing Clubs",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "fengshui",
+        "title": "Feng Shui",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "ferries",
+        "title": "Ferries",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "fertility",
+        "title": "Fertility",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "festivals",
+        "title": "Festivals",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "filipino",
+        "title": "Filipino",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "CZ",
+            "FI",
+            "DK"
+        ]
+    },
+    {
+        "alias": "financialadvising",
+        "title": "Financial Advising",
+        "parents": [
+            "financialservices"
+        ]
+    },
+    {
+        "alias": "financialservices",
+        "title": "Financial Services",
+        "parents": []
+    },
+    {
+        "alias": "fingerprinting",
+        "title": "Fingerprinting",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "firearmtraining",
+        "title": "Firearm Training",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "firedepartments",
+        "title": "Fire Departments",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_blacklist": [
+            "CA",
+            "NZ",
+            "GB",
+            "SG",
+            "IE"
+        ]
+    },
+    {
+        "alias": "fireplace",
+        "title": "Fireplace Services",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "fireprotection",
+        "title": "Fire Protection Services",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "firewood",
+        "title": "Firewood",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "JP",
+            "TW",
+            "PH",
+            "HK",
+            "NL",
+            "BE",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "fireworks",
+        "title": "Fireworks",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "US",
+            "PT",
+            "AR",
+            "CA",
+            "MX",
+            "CZ",
+            "AU",
+            "CL"
+        ]
+    },
+    {
+        "alias": "firstaidclasses",
+        "title": "First Aid Classes",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_blacklist": [
+            "NL",
+            "FR",
+            "NZ",
+            "BE",
+            "BR",
+            "SG",
+            "IE"
+        ]
+    },
+    {
+        "alias": "fischbroetchen",
+        "title": "Fischbroetchen",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "fishing",
+        "title": "Fishing",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "fishmonger",
+        "title": "Fishmonger",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "AT",
+            "PT",
+            "NL",
+            "DK",
+            "BE",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "fishnchips",
+        "title": "Fish & Chips",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "BR",
+            "PT"
+        ]
+    },
+    {
+        "alias": "fitness",
+        "title": "Fitness & Instruction",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "fitnessequipment",
+        "title": "Fitness/Exercise Equipment",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "flatbread",
+        "title": "Flatbread",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "DK",
+            "CH",
+            "PL",
+            "AT"
+        ]
+    },
+    {
+        "alias": "fleamarkets",
+        "title": "Flea Markets",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "flemish",
+        "title": "Flemish",
+        "parents": [
+            "belgian"
+        ],
+        "country_whitelist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "flightinstruction",
+        "title": "Flight Instruction",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "floatspa",
+        "title": "Float Spa",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "FR",
+            "JP",
+            "IT"
+        ]
+    },
+    {
+        "alias": "flooring",
+        "title": "Flooring",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "floraldesigners",
+        "title": "Floral Designers",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "florists",
+        "title": "Florists",
+        "parents": [
+            "flowers"
+        ]
+    },
+    {
+        "alias": "flowers",
+        "title": "Flowers & Gifts",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "flyboarding",
+        "title": "Flyboarding",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "fondue",
+        "title": "Fondue",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "ES",
+            "CZ",
+            "DK"
+        ]
+    },
+    {
+        "alias": "food",
+        "title": "Food",
+        "parents": []
+    },
+    {
+        "alias": "food_court",
+        "title": "Food Court",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "TW",
+            "ES",
+            "FR",
+            "AR",
+            "FI",
+            "MX",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "foodbanks",
+        "title": "Food Banks",
+        "parents": [
+            "nonprofit"
+        ]
+    },
+    {
+        "alias": "fooddeliveryservices",
+        "title": "Food Delivery Services",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "foodsafety",
+        "title": "Food Safety Training",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "SG",
+            "BR",
+            "US",
+            "PT"
+        ]
+    },
+    {
+        "alias": "foodstands",
+        "title": "Food Stands",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "foodtours",
+        "title": "Food Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "foodtrucks",
+        "title": "Food Trucks",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "SG"
+        ]
+    },
+    {
+        "alias": "football",
+        "title": "Soccer",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "forestry",
+        "title": "Forestry",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "SE",
+            "CA",
+            "DK",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "formalwear",
+        "title": "Formal Wear",
+        "parents": [
+            "fashion"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "MY",
+            "CH",
+            "GB",
+            "JP",
+            "IE",
+            "TW",
+            "PH",
+            "HK",
+            "PL",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "foundationrepair",
+        "title": "Foundation Repair",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "framing",
+        "title": "Framing",
+        "parents": [
+            "artsandcrafts"
+        ]
+    },
+    {
+        "alias": "franconian",
+        "title": "Franconian",
+        "parents": [
+            "german"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "freediving",
+        "title": "Free Diving",
+        "parents": [
+            "diving"
+        ]
+    },
+    {
+        "alias": "freiduria",
+        "title": "Freiduria",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "MX",
+            "AR",
+            "ES",
+            "CL"
+        ]
+    },
+    {
+        "alias": "french",
+        "title": "French",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "friterie",
+        "title": "Friterie",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "NL",
+            "FR",
+            "BE",
+            "AU",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "friulan",
+        "title": "Friulan",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "frozenfood",
+        "title": "Frozen Food",
+        "parents": [
+            "gourmet"
+        ],
+        "country_whitelist": [
+            "ES",
+            "FR",
+            "BE",
+            "GB",
+            "SG",
+            "IT"
+        ]
+    },
+    {
+        "alias": "fueldocks",
+        "title": "Fuel Docks",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "ES",
+            "SE",
+            "US",
+            "DK",
+            "MX",
+            "NO"
+        ]
+    },
+    {
+        "alias": "funeralservices",
+        "title": "Funeral Services & Cemeteries",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "funfair",
+        "title": "Fun Fair",
+        "parents": [
+            "festivals"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "PT",
+            "NL",
+            "DK",
+            "BE",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "furclothing",
+        "title": "Fur Clothing",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "furniture",
+        "title": "Furniture Stores",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "furnitureassembly",
+        "title": "Furniture Assembly",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "furniturerepair",
+        "title": "Furniture Repair",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "fuzhou",
+        "title": "Fuzhou",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "MY",
+            "HK"
+        ]
+    },
+    {
+        "alias": "galician",
+        "title": "Galician",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT"
+        ]
+    },
+    {
+        "alias": "galleries",
+        "title": "Art Galleries",
+        "parents": [
+            "shopping",
+            "arts"
+        ]
+    },
+    {
+        "alias": "gamemeat",
+        "title": "Game Meat",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "JP",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "AR",
+            "CA",
+            "FI",
+            "MX",
+            "BR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "gametruckrental",
+        "title": "Game Truck Rental",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "AR",
+            "CA",
+            "MX",
+            "CL"
+        ]
+    },
+    {
+        "alias": "garage_door_services",
+        "title": "Garage Door Services",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "DE",
+            "SE",
+            "MY",
+            "CH",
+            "JP",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "AR",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "gardeners",
+        "title": "Gardeners",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "gardening",
+        "title": "Nurseries & Gardening",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "gardens",
+        "title": "Botanical Gardens",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "gastroenterologist",
+        "title": "Gastroenterologist",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "gastropubs",
+        "title": "Gastropubs",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "gaybars",
+        "title": "Gay Bars",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "gelato",
+        "title": "Gelato",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "SE",
+            "SG",
+            "US",
+            "PH",
+            "PT",
+            "DK",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "gemstonesandminerals",
+        "title": "Gemstones & Minerals",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "general_litigation",
+        "title": "General Litigation",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "generaldentistry",
+        "title": "General Dentistry",
+        "parents": [
+            "dentists"
+        ]
+    },
+    {
+        "alias": "generalfestivals",
+        "title": "General Festivals",
+        "parents": [
+            "festivals"
+        ],
+        "country_whitelist": [
+            "PT",
+            "DE",
+            "CH",
+            "JP",
+            "AT"
+        ]
+    },
+    {
+        "alias": "generatorinstallrepair",
+        "title": "Generator Installation/Repair",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "geneticists",
+        "title": "Geneticists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "georgian",
+        "title": "Georgian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "GB",
+            "AT",
+            "US",
+            "CZ",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "german",
+        "title": "German",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "gerontologist",
+        "title": "Gerontologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "gestorias",
+        "title": "Gestorias",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "MX",
+            "AR",
+            "ES",
+            "CL"
+        ]
+    },
+    {
+        "alias": "giblets",
+        "title": "Giblets",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "giftshops",
+        "title": "Gift Shops",
+        "parents": [
+            "flowers"
+        ],
+        "country_blacklist": [
+            "SG",
+            "TR",
+            "PL"
+        ]
+    },
+    {
+        "alias": "glassandmirrors",
+        "title": "Glass & Mirrors",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "glassblowing",
+        "title": "Glass Blowing",
+        "parents": [
+            "artclasses"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "gliding",
+        "title": "Gliding",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "AT",
+            "PT",
+            "FR",
+            "CZ",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "gluhwein",
+        "title": "Mulled Wine",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "SE",
+            "DE",
+            "CH",
+            "CZ",
+            "AT"
+        ]
+    },
+    {
+        "alias": "gluten_free",
+        "title": "Gluten-Free",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "gokarts",
+        "title": "Go Karts",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "goldbuyers",
+        "title": "Gold Buyers",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "AT",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "FR",
+            "CA",
+            "BE",
+            "BR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "golf",
+        "title": "Golf",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "golfcartdealers",
+        "title": "Golf Cart Dealers",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "golfcartrentals",
+        "title": "Golf Cart Rentals",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "golfequipment",
+        "title": "Golf Equipment",
+        "parents": [
+            "sportgoods"
+        ],
+        "country_whitelist": [
+            "US",
+            "DE",
+            "NL",
+            "CA",
+            "BE",
+            "AU"
+        ]
+    },
+    {
+        "alias": "golflessons",
+        "title": "Golf Lessons",
+        "parents": [
+            "fitness"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "MY",
+            "CH",
+            "SG",
+            "IE",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "CA",
+            "BR",
+            "FI"
+        ]
+    },
+    {
+        "alias": "gourmet",
+        "title": "Specialty Food",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "gozleme",
+        "title": "Gozleme",
+        "parents": [
+            "turkish"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "graphicdesign",
+        "title": "Graphic Design",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "greek",
+        "title": "Greek",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "grillingequipment",
+        "title": "Grilling Equipment",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "grocery",
+        "title": "Grocery",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "groomer",
+        "title": "Pet Groomers",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "groutservices",
+        "title": "Grout Services",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "guamanian",
+        "title": "Guamanian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "FR",
+            "AR",
+            "MX",
+            "JP",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "guesthouses",
+        "title": "Guest Houses",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_blacklist": [
+            "SG"
+        ]
+    },
+    {
+        "alias": "guitarstores",
+        "title": "Guitar Stores",
+        "parents": [
+            "musicinstrumentservices"
+        ]
+    },
+    {
+        "alias": "gun_ranges",
+        "title": "Gun/Rifle Ranges",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SG",
+            "BE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "guns_and_ammo",
+        "title": "Guns & Ammo",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "DE",
+            "MY",
+            "CH",
+            "AT",
+            "ES",
+            "PH",
+            "PT",
+            "US",
+            "AR",
+            "CA",
+            "MX",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "gunsmith",
+        "title": "Gunsmith",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "CH",
+            "JP",
+            "AT",
+            "TW",
+            "HK",
+            "NL",
+            "BE",
+            "BR"
+        ]
+    },
+    {
+        "alias": "gutterservices",
+        "title": "Gutter Services",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR"
+        ]
+    },
+    {
+        "alias": "gymnastics",
+        "title": "Gymnastics",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "US",
+            "PT",
+            "CA",
+            "DK",
+            "MX",
+            "BR",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "gyms",
+        "title": "Gyms",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "gyudon",
+        "title": "Gyudon",
+        "parents": [
+            "donburi"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "habilitativeservices",
+        "title": "Habilitative Services",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "hainan",
+        "title": "Hainan",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "US",
+            "PH",
+            "HK",
+            "MY",
+            "SG"
+        ]
+    },
+    {
+        "alias": "hair",
+        "title": "Hair Salons",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "hair_extensions",
+        "title": "Hair Extensions",
+        "parents": [
+            "beautysvc",
+            "hair"
+        ],
+        "country_blacklist": [
+            "TR",
+            "HK",
+            "NL",
+            "BE",
+            "PL"
+        ]
+    },
+    {
+        "alias": "hairloss",
+        "title": "Hair Loss Centers",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "hairremoval",
+        "title": "Hair Removal",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "hairstylists",
+        "title": "Hair Stylists",
+        "parents": [
+            "hair"
+        ],
+        "country_whitelist": [
+            "SE",
+            "SG",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "AR",
+            "DK",
+            "MX",
+            "BE",
+            "CZ",
+            "AU",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "haitian",
+        "title": "Haitian",
+        "parents": [
+            "caribbean"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "hakka",
+        "title": "Hakka",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "PH",
+            "HK",
+            "CA",
+            "MY",
+            "SG"
+        ]
+    },
+    {
+        "alias": "halal",
+        "title": "Halal",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "PT"
+        ]
+    },
+    {
+        "alias": "halfwayhouses",
+        "title": "Halfway Houses",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "halotherapy",
+        "title": "Halotherapy",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "handball",
+        "title": "Handball",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "NZ",
+            "SG",
+            "TW",
+            "HK",
+            "MX",
+            "CZ",
+            "MY",
+            "GB",
+            "IE",
+            "US",
+            "PH",
+            "PT",
+            "CA",
+            "AU"
+        ]
+    },
+    {
+        "alias": "handrolls",
+        "title": "Hand Rolls",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "BR"
+        ]
+    },
+    {
+        "alias": "handyman",
+        "title": "Handyman",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "hanggliding",
+        "title": "Hang Gliding",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "MY",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "PH",
+            "HK",
+            "NL",
+            "CA",
+            "DK",
+            "CZ",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "hardware",
+        "title": "Hardware Stores",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "hats",
+        "title": "Hats",
+        "parents": [
+            "fashion"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "CH",
+            "GB",
+            "JP",
+            "IE",
+            "AT",
+            "HK",
+            "PL"
+        ]
+    },
+    {
+        "alias": "hauntedhouses",
+        "title": "Haunted Houses",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "hawaiian",
+        "title": "Hawaiian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "PT",
+            "DK",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "hawkercentre",
+        "title": "Hawker Centre",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "TW",
+            "PH",
+            "HK",
+            "MY",
+            "SG"
+        ]
+    },
+    {
+        "alias": "hazardouswastedisposal",
+        "title": "Hazardous Waste Disposal",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "SE",
+            "MY",
+            "CH",
+            "JP",
+            "AT",
+            "PH",
+            "HK",
+            "PT",
+            "FR",
+            "BR",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "headshops",
+        "title": "Head Shops",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "health",
+        "title": "Health & Medical",
+        "parents": []
+    },
+    {
+        "alias": "healthcoach",
+        "title": "Health Coach",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "healthinsurance",
+        "title": "Health Insurance Offices",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "SG",
+            "US",
+            "PT",
+            "FR",
+            "MX",
+            "BE",
+            "BR",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "healthmarkets",
+        "title": "Health Markets",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "healthretreats",
+        "title": "Health Retreats",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR"
+        ]
+    },
+    {
+        "alias": "healthtrainers",
+        "title": "Trainers",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "hearing_aids",
+        "title": "Hearing Aids",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "CL",
+            "AT",
+            "ES",
+            "PT",
+            "FR",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "CZ",
+            "PL",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "hearingaidproviders",
+        "title": "Hearing Aid Providers",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "AT",
+            "ES",
+            "HK",
+            "MX",
+            "CZ",
+            "CL",
+            "SE",
+            "GB",
+            "IE",
+            "AR",
+            "AU"
+        ]
+    },
+    {
+        "alias": "henghwa",
+        "title": "Henghwa",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "MY",
+            "HK"
+        ]
+    },
+    {
+        "alias": "hennaartists",
+        "title": "Henna Artists",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "FR",
+            "NZ",
+            "BR",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "hepatologists",
+        "title": "Hepatologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "herbalshops",
+        "title": "Herbal Shops",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "herbsandspices",
+        "title": "Herbs & Spices",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "hessian",
+        "title": "Hessian",
+        "parents": [
+            "german"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "heuriger",
+        "title": "Heuriger",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "AT"
+        ]
+    },
+    {
+        "alias": "hifi",
+        "title": "High Fidelity Audio Equipment",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "highschools",
+        "title": "Middle Schools & High Schools",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "hiking",
+        "title": "Hiking",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "himalayan",
+        "title": "Himalayan/Nepalese",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "hindu_temples",
+        "title": "Hindu Temples",
+        "parents": [
+            "religiousorgs"
+        ]
+    },
+    {
+        "alias": "historicaltours",
+        "title": "Historical Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "hkcafe",
+        "title": "Hong Kong Style Cafe",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TW",
+            "CA",
+            "US",
+            "HK"
+        ]
+    },
+    {
+        "alias": "hobbyshops",
+        "title": "Hobby Shops",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "hockeyequipment",
+        "title": "Hockey Equipment",
+        "parents": [
+            "sportgoods"
+        ]
+    },
+    {
+        "alias": "hokkien",
+        "title": "Hokkien",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "MY",
+            "HK"
+        ]
+    },
+    {
+        "alias": "holidaydecorations",
+        "title": "Holiday Decorations",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "home_inspectors",
+        "title": "Home Inspectors",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "home_organization",
+        "title": "Home Organization",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "homeandgarden",
+        "title": "Home & Garden",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "homeappliancerepair",
+        "title": "Appliances & Repair",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "homeautomation",
+        "title": "Home Automation",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "homecleaning",
+        "title": "Home Cleaning",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "homedecor",
+        "title": "Home Decor",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "homedevelopers",
+        "title": "Home Developers",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "AR",
+            "MX",
+            "BR",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "homeenergyauditors",
+        "title": "Home Energy Auditors",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "AT",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "FR",
+            "CA",
+            "BE",
+            "FI"
+        ]
+    },
+    {
+        "alias": "homehealthcare",
+        "title": "Home Health Care",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "homeinsurance",
+        "title": "Home & Rental Insurance",
+        "parents": [
+            "insurance"
+        ]
+    },
+    {
+        "alias": "homelessshelters",
+        "title": "Homeless Shelters",
+        "parents": [
+            "nonprofit"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "homemadefood",
+        "title": "Homemade Food",
+        "parents": [
+            "turkish"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "homenetworkinstall",
+        "title": "Home Network Installation",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "AT",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "DK",
+            "BE",
+            "BR",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "homeopathic",
+        "title": "Homeopathic",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "US",
+            "HK",
+            "CA",
+            "AU"
+        ]
+    },
+    {
+        "alias": "homeownerassociation",
+        "title": "Homeowner Association",
+        "parents": [
+            "realestate"
+        ],
+        "country_whitelist": [
+            "US",
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "homeservices",
+        "title": "Home Services",
+        "parents": []
+    },
+    {
+        "alias": "homestaging",
+        "title": "Home Staging",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT",
+            "ES",
+            "PT",
+            "FR",
+            "BR",
+            "CZ",
+            "IT"
+        ]
+    },
+    {
+        "alias": "hometheatreinstallation",
+        "title": "Home Theatre Installation",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "CZ",
+            "DK"
+        ]
+    },
+    {
+        "alias": "homewindowtinting",
+        "title": "Home Window Tinting",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "PT",
+            "NL",
+            "CA",
+            "BE",
+            "AU"
+        ]
+    },
+    {
+        "alias": "honduran",
+        "title": "Honduran",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "JP"
+        ]
+    },
+    {
+        "alias": "honey",
+        "title": "Honey",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "SE",
+            "US",
+            "FR",
+            "PL",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "hookah_bars",
+        "title": "Hookah Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "SG",
+            "PT",
+            "CL",
+            "AU"
+        ]
+    },
+    {
+        "alias": "horse_boarding",
+        "title": "Horse Boarding",
+        "parents": [
+            "pets"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "NZ",
+            "GB",
+            "IE",
+            "US",
+            "FR",
+            "CA",
+            "DK",
+            "CZ",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "horsebackriding",
+        "title": "Horseback Riding",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "horsequipment",
+        "title": "Horse Equipment Shops",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "MY",
+            "CH",
+            "JP",
+            "TW",
+            "PH",
+            "HK"
+        ]
+    },
+    {
+        "alias": "horseracing",
+        "title": "Horse Racing",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "MY",
+            "GB",
+            "SG",
+            "IE",
+            "PH",
+            "FR",
+            "CA",
+            "BR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "horumon",
+        "title": "Horumon",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "hospice",
+        "title": "Hospice",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "hospitalists",
+        "title": "Hospitalists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "CH",
+            "JP",
+            "IT",
+            "AT"
+        ]
+    },
+    {
+        "alias": "hospitals",
+        "title": "Hospitals",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "hostels",
+        "title": "Hostels",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "hot_air_balloons",
+        "title": "Hot Air Balloons",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SG",
+            "BR",
+            "CA",
+            "NZ"
+        ]
+    },
+    {
+        "alias": "hotdog",
+        "title": "Hot Dogs",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "hotdogs",
+        "title": "Fast Food",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "hotel_bar",
+        "title": "Hotel bar",
+        "parents": [
+            "bars"
+        ],
+        "country_whitelist": [
+            "PT",
+            "SE",
+            "DK",
+            "BR",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "hotels",
+        "title": "Hotels",
+        "parents": [
+            "hotelstravel",
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "hotelstravel",
+        "title": "Hotels & Travel",
+        "parents": []
+    },
+    {
+        "alias": "hotpot",
+        "title": "Hot Pot",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "SE",
+            "MY",
+            "JP",
+            "SG",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "FR",
+            "CA",
+            "BR"
+        ]
+    },
+    {
+        "alias": "hotsprings",
+        "title": "Hot Springs",
+        "parents": [
+            "beautysvc"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "AT",
+            "TW",
+            "US",
+            "BR",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "hottubandpool",
+        "title": "Hot Tub & Pool",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "housesitters",
+        "title": "House Sitters",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "IT",
+            "AU"
+        ]
+    },
+    {
+        "alias": "housingcooperatives",
+        "title": "Housing Cooperatives",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "hunan",
+        "title": "Hunan",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "HK",
+            "FR",
+            "MY",
+            "SG"
+        ]
+    },
+    {
+        "alias": "hungarian",
+        "title": "Hungarian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "huntingfishingsupplies",
+        "title": "Hunting & Fishing Supplies",
+        "parents": [
+            "sportgoods"
+        ]
+    },
+    {
+        "alias": "hvac",
+        "title": "Heating & Air Conditioning/HVAC",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "hybridcarrepair",
+        "title": "Hybrid Car Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "SE",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "CZ",
+            "AU",
+            "PL"
+        ]
+    },
+    {
+        "alias": "hydrojetting",
+        "title": "Hydro-jetting",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "hydroponics",
+        "title": "Hydroponics",
+        "parents": [
+            "gardening"
+        ]
+    },
+    {
+        "alias": "hydrotherapy",
+        "title": "Hydrotherapy",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "hypnosis",
+        "title": "Hypnosis/Hypnotherapy",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "NL",
+            "TR",
+            "HK"
+        ]
+    },
+    {
+        "alias": "iberian",
+        "title": "Iberian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US",
+            "PT"
+        ]
+    },
+    {
+        "alias": "icecream",
+        "title": "Ice Cream & Frozen Yogurt",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "icedelivery",
+        "title": "Ice Delivery",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "immigrationlawyers",
+        "title": "Immigration Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "immunodermatologists",
+        "title": "Immunodermatologists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "FR",
+            "JP"
+        ]
+    },
+    {
+        "alias": "importedfood",
+        "title": "Imported Food",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "indonesian",
+        "title": "Indonesian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "MX",
+            "ES"
+        ]
+    },
+    {
+        "alias": "indoor_playcenter",
+        "title": "Indoor Playcentre",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "CH",
+            "CL",
+            "SG",
+            "IE",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "AR",
+            "MX",
+            "BR",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "indoorlandscaping",
+        "title": "Indoor Landscaping",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "indpak",
+        "title": "Indian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "infectiousdisease",
+        "title": "Infectious Disease Specialists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "installmentloans",
+        "title": "Installment Loans",
+        "parents": [
+            "financialservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "insulationinstallation",
+        "title": "Insulation Installation",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "insurance",
+        "title": "Insurance",
+        "parents": [
+            "financialservices"
+        ]
+    },
+    {
+        "alias": "interiordesign",
+        "title": "Interior Design",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "interlocksystems",
+        "title": "Interlock Systems",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "internalmed",
+        "title": "Internal Medicine",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "international",
+        "title": "International",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "US",
+            "PH",
+            "MY",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "internetbooth",
+        "title": "Internet Booths & Calling Centers",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "ES",
+            "AR",
+            "MX",
+            "BR",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "internetcafe",
+        "title": "Internet Cafes",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "intervaltraininggyms",
+        "title": "Interval Training Gyms",
+        "parents": [
+            "gyms"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "intlgrocery",
+        "title": "International Grocery",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "investing",
+        "title": "Investing",
+        "parents": [
+            "financialservices"
+        ]
+    },
+    {
+        "alias": "iplaw",
+        "title": "IP & Internet Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_whitelist": [
+            "US",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "irish",
+        "title": "Irish",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "irish_pubs",
+        "title": "Irish Pub",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "irrigation",
+        "title": "Irrigation",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "island_pub",
+        "title": "Island Pub",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "SE"
+        ]
+    },
+    {
+        "alias": "isps",
+        "title": "Internet Service Providers",
+        "parents": [
+            "homeservices",
+            "professional"
+        ]
+    },
+    {
+        "alias": "israeli",
+        "title": "Israeli",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CZ",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "italian",
+        "title": "Italian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "itservices",
+        "title": "IT Services & Computer Repair",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "ivhydration",
+        "title": "IV Hydration",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "izakaya",
+        "title": "Izakaya",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "JP",
+            "SG",
+            "TW",
+            "US",
+            "HK",
+            "MX",
+            "BR",
+            "AU"
+        ]
+    },
+    {
+        "alias": "jailsandprisons",
+        "title": "Jails & Prisons",
+        "parents": [
+            "publicservicesgovt"
+        ]
+    },
+    {
+        "alias": "jaliscan",
+        "title": "Jaliscan",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "japacurry",
+        "title": "Japanese Curry",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "US",
+            "HK",
+            "JP",
+            "SG"
+        ]
+    },
+    {
+        "alias": "japanese",
+        "title": "Japanese",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "jazzandblues",
+        "title": "Jazz & Blues",
+        "parents": [
+            "arts",
+            "nightlife"
+        ]
+    },
+    {
+        "alias": "jetskis",
+        "title": "Jet Skis",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "jewelry",
+        "title": "Jewelry",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "jewelryrepair",
+        "title": "Jewelry Repair",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "DE",
+            "SE",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "TW",
+            "HK",
+            "FI"
+        ]
+    },
+    {
+        "alias": "jewish",
+        "title": "Jewish",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "PL",
+            "IT",
+            "DE"
+        ]
+    },
+    {
+        "alias": "jpsweets",
+        "title": "Japanese Sweets",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "juicebars",
+        "title": "Juice Bars & Smoothies",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "junkremovalandhauling",
+        "title": "Junk Removal & Hauling",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "junkyards",
+        "title": "Junkyards",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "SG",
+            "AT",
+            "DK",
+            "BE",
+            "CZ",
+            "SE",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "FR",
+            "CA",
+            "BR",
+            "AU",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "kaiseki",
+        "title": "Kaiseki",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "karaoke",
+        "title": "Karaoke",
+        "parents": [
+            "nightlife"
+        ]
+    },
+    {
+        "alias": "karaokerental",
+        "title": "Karaoke Rental",
+        "parents": [
+            "partyequipmentrentals"
+        ]
+    },
+    {
+        "alias": "karate",
+        "title": "Karate",
+        "parents": [
+            "martialarts"
+        ]
+    },
+    {
+        "alias": "kebab",
+        "title": "Kebab",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "kickboxing",
+        "title": "Kickboxing",
+        "parents": [
+            "martialarts"
+        ]
+    },
+    {
+        "alias": "kids_activities",
+        "title": "Kids Activities",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SG"
+        ]
+    },
+    {
+        "alias": "kidshairsalons",
+        "title": "Kids Hair Salons",
+        "parents": [
+            "hair"
+        ]
+    },
+    {
+        "alias": "kimonos",
+        "title": "Kimonos",
+        "parents": [
+            "fashion"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "kiosk",
+        "title": "Kiosk",
+        "parents": [
+            "shopping",
+            "food"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "HK",
+            "FR",
+            "CA",
+            "BR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "kitchenandbath",
+        "title": "Kitchen & Bath",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "kitchenincubators",
+        "title": "Kitchen Incubators",
+        "parents": [
+            "realestate"
+        ],
+        "country_whitelist": [
+            "GB",
+            "US"
+        ]
+    },
+    {
+        "alias": "kitchensupplies",
+        "title": "Kitchen Supplies",
+        "parents": [
+            "kitchenandbath"
+        ]
+    },
+    {
+        "alias": "kiteboarding",
+        "title": "Kiteboarding",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "CH",
+            "GB",
+            "AT",
+            "HK",
+            "CA",
+            "CZ",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "knifesharpening",
+        "title": "Knife Sharpening",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "knittingsupplies",
+        "title": "Knitting Supplies",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "kombucha",
+        "title": "Kombucha",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "kopitiam",
+        "title": "Kopitiam",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "SG",
+            "MY"
+        ]
+    },
+    {
+        "alias": "korean",
+        "title": "Korean",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "kosher",
+        "title": "Kosher",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "PT"
+        ]
+    },
+    {
+        "alias": "kurdish",
+        "title": "Kurdish",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "NO",
+            "SE"
+        ]
+    },
+    {
+        "alias": "kushikatsu",
+        "title": "Kushikatsu",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "laboratorytesting",
+        "title": "Laboratory Testing",
+        "parents": [
+            "diagnosticservices"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "US",
+            "FR",
+            "AR",
+            "MX",
+            "BE",
+            "BR",
+            "CZ",
+            "AU",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "lactationservices",
+        "title": "Lactation Services",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT",
+            "FR",
+            "BE",
+            "BR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "lahmacun",
+        "title": "Lahmacun",
+        "parents": [
+            "turkish"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "lakes",
+        "title": "Lakes",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "lancenters",
+        "title": "LAN Centers",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "MY",
+            "IT",
+            "PH"
+        ]
+    },
+    {
+        "alias": "landmarks",
+        "title": "Landmarks & Historical Buildings",
+        "parents": [
+            "publicservicesgovt"
+        ]
+    },
+    {
+        "alias": "landscapearchitects",
+        "title": "Landscape Architects",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "landscaping",
+        "title": "Landscaping",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "landsurveying",
+        "title": "Land Surveying",
+        "parents": [
+            "realestatesvcs"
+        ],
+        "country_blacklist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "language_schools",
+        "title": "Language Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "laos",
+        "title": "Laos",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "AU"
+        ]
+    },
+    {
+        "alias": "laotian",
+        "title": "Laotian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "laser_hair_removal",
+        "title": "Laser Hair Removal",
+        "parents": [
+            "hairremoval"
+        ]
+    },
+    {
+        "alias": "laserlasikeyes",
+        "title": "Laser Eye Surgery/Lasik",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "lasertag",
+        "title": "Laser Tag",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "BR",
+            "IE"
+        ]
+    },
+    {
+        "alias": "latin",
+        "title": "Latin American",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "laundromat",
+        "title": "Laundromat",
+        "parents": [
+            "laundryservices"
+        ]
+    },
+    {
+        "alias": "laundryservices",
+        "title": "Laundry Services",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "lawn_bowling",
+        "title": "Lawn Bowling",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "PT",
+            "SE",
+            "NZ",
+            "AU",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "lawnservices",
+        "title": "Lawn Services",
+        "parents": [
+            "landscaping"
+        ],
+        "country_whitelist": [
+            "NL",
+            "BE",
+            "BR",
+            "US"
+        ]
+    },
+    {
+        "alias": "lawyers",
+        "title": "Lawyers",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "leather",
+        "title": "Leather Goods",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "lebanese",
+        "title": "Lebanese",
+        "parents": [
+            "mideastern"
+        ],
+        "country_blacklist": [
+            "AR",
+            "JP",
+            "HK"
+        ]
+    },
+    {
+        "alias": "legalservices",
+        "title": "Legal Services",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "DE",
+            "SE",
+            "MY",
+            "CH",
+            "GB",
+            "CL",
+            "IE",
+            "AT",
+            "TW",
+            "ES",
+            "PH",
+            "HK",
+            "AR",
+            "MX",
+            "FI"
+        ]
+    },
+    {
+        "alias": "libraries",
+        "title": "Libraries",
+        "parents": [
+            "publicservicesgovt"
+        ]
+    },
+    {
+        "alias": "liceservices",
+        "title": "Lice Services",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "DE",
+            "JP",
+            "HK",
+            "AR",
+            "FI",
+            "MX",
+            "CZ",
+            "CL"
+        ]
+    },
+    {
+        "alias": "lifecoach",
+        "title": "Life Coach",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "lifeinsurance",
+        "title": "Life Insurance",
+        "parents": [
+            "insurance"
+        ],
+        "country_blacklist": [
+            "DE",
+            "MY",
+            "CH",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "FR",
+            "CA",
+            "FI"
+        ]
+    },
+    {
+        "alias": "lighting",
+        "title": "Lighting Fixtures & Equipment",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "lightingstores",
+        "title": "Lighting Stores",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "ligurian",
+        "title": "Ligurian",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "limos",
+        "title": "Limos",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "linens",
+        "title": "Linens",
+        "parents": [
+            "homeandgarden"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "PT",
+            "FR",
+            "DK",
+            "BE",
+            "CZ",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "lingerie",
+        "title": "Lingerie",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "livestocksupply",
+        "title": "Livestock Feed & Supply",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "localfishstores",
+        "title": "Local Fish Stores",
+        "parents": [
+            "petstore"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "JP",
+            "SG",
+            "ES",
+            "US",
+            "NL",
+            "FR",
+            "DK",
+            "BE",
+            "CZ",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "localflavor",
+        "title": "Local Flavor",
+        "parents": []
+    },
+    {
+        "alias": "localservices",
+        "title": "Local Services",
+        "parents": []
+    },
+    {
+        "alias": "locksmiths",
+        "title": "Keys & Locksmiths",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "lounges",
+        "title": "Lounges",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "luggage",
+        "title": "Luggage",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "luggagestorage",
+        "title": "Luggage Storage",
+        "parents": [
+            "travelservices"
+        ]
+    },
+    {
+        "alias": "lumbard",
+        "title": "Lumbard",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "lyonnais",
+        "title": "Lyonnais",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "BE",
+            "FR"
+        ]
+    },
+    {
+        "alias": "macarons",
+        "title": "Macarons",
+        "parents": [
+            "gourmet"
+        ],
+        "country_blacklist": [
+            "MY",
+            "IT",
+            "PH"
+        ]
+    },
+    {
+        "alias": "machinerental",
+        "title": "Machine & Tool Rental",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "machineshops",
+        "title": "Machine Shops",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "madeira",
+        "title": "Madeira",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "magicians",
+        "title": "Magicians",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "SG",
+            "SE",
+            "TR",
+            "FI"
+        ]
+    },
+    {
+        "alias": "mags",
+        "title": "Newspapers & Magazines",
+        "parents": [
+            "media"
+        ]
+    },
+    {
+        "alias": "mahjong",
+        "title": "Mah Jong Halls",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "JP",
+            "HK"
+        ]
+    },
+    {
+        "alias": "mailboxcenters",
+        "title": "Mailbox Centers",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "makerspaces",
+        "title": "Makerspaces",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "makeupartists",
+        "title": "Makeup Artists",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "malaysian",
+        "title": "Malaysian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "CZ",
+            "PT"
+        ]
+    },
+    {
+        "alias": "mamak",
+        "title": "Mamak",
+        "parents": [
+            "malaysian"
+        ],
+        "country_whitelist": [
+            "MY",
+            "AU"
+        ]
+    },
+    {
+        "alias": "marchingbands",
+        "title": "Marching Bands",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "SE",
+            "CH",
+            "GB",
+            "AT",
+            "PT",
+            "NO"
+        ]
+    },
+    {
+        "alias": "marinas",
+        "title": "Marinas",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "SG",
+            "AT",
+            "ES",
+            "DK",
+            "MX",
+            "BE",
+            "CL",
+            "SE",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "FR",
+            "AR",
+            "CA",
+            "BR",
+            "AU",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "marketing",
+        "title": "Marketing",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "markets",
+        "title": "Fruits & Veggies",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "marketstalls",
+        "title": "Market Stalls",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "GB",
+            "IE",
+            "AT",
+            "PT",
+            "DK",
+            "CZ",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "martialarts",
+        "title": "Martial Arts",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "masonry_concrete",
+        "title": "Masonry/Concrete",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "NL",
+            "NZ",
+            "BE",
+            "GB",
+            "BR",
+            "SG",
+            "IE"
+        ]
+    },
+    {
+        "alias": "massage",
+        "title": "Massage",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "massage_schools",
+        "title": "Massage Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "massage_therapy",
+        "title": "Massage Therapy",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "SG",
+            "AT",
+            "TW",
+            "HK",
+            "CZ",
+            "SE",
+            "MY",
+            "IE",
+            "PH",
+            "FR",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "massmedia",
+        "title": "Mass Media",
+        "parents": []
+    },
+    {
+        "alias": "matchmakers",
+        "title": "Matchmakers",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "JP",
+            "ES",
+            "PT",
+            "US",
+            "FR",
+            "AR",
+            "CA",
+            "DK",
+            "MX",
+            "AU",
+            "PL",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "materialeelettrico",
+        "title": "Materiale elettrico",
+        "parents": [
+            "homeandgarden"
+        ],
+        "country_whitelist": [
+            "ES",
+            "AR",
+            "MX",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "maternity",
+        "title": "Maternity Wear",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "mattresses",
+        "title": "Mattresses",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "mauritius",
+        "title": "Mauritius",
+        "parents": [
+            "french"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "AT",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "AU",
+            "PL",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "meatballs",
+        "title": "Meatballs",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "NL",
+            "BE",
+            "TR",
+            "FR"
+        ]
+    },
+    {
+        "alias": "meats",
+        "title": "Meat Shops",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "medcenters",
+        "title": "Medical Centers",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "media",
+        "title": "Books, Mags, Music & Video",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "mediators",
+        "title": "Mediators",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "medicalfoot",
+        "title": "Medical Foot Care",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "CL",
+            "JP",
+            "ES",
+            "PH",
+            "PT",
+            "US",
+            "AR",
+            "MX",
+            "BR",
+            "CZ",
+            "PL",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "medicallaw",
+        "title": "Medical Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "medicalspa",
+        "title": "Medical Spas",
+        "parents": [
+            "health",
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "medicalsupplies",
+        "title": "Medical Supplies",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "medicaltransportation",
+        "title": "Medical Transportation",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "SG",
+            "AT",
+            "US",
+            "PT",
+            "NL",
+            "FR",
+            "DK",
+            "BE",
+            "BR",
+            "AU",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "meditationcenters",
+        "title": "Meditation Centers",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "mediterranean",
+        "title": "Mediterranean",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "memorycare",
+        "title": "Memory Care",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "menscloth",
+        "title": "Men's Clothing",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "menshair",
+        "title": "Men's Hair Salons",
+        "parents": [
+            "hair"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "AR",
+            "DK",
+            "MX",
+            "BE",
+            "CZ",
+            "AU",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "metaldetectorservices",
+        "title": "Metal Detector Services",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "metalfabricators",
+        "title": "Metal Fabricators",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "SE"
+        ]
+    },
+    {
+        "alias": "metrostations",
+        "title": "Metro Stations",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "mexican",
+        "title": "Mexican",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "mideastern",
+        "title": "Middle Eastern",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "midwives",
+        "title": "Midwives",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "militarysurplus",
+        "title": "Military Surplus",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "milkbars",
+        "title": "Milk Bars",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "PL",
+            "AU"
+        ]
+    },
+    {
+        "alias": "milkshakebars",
+        "title": "Milkshake Bars",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "GB"
+        ]
+    },
+    {
+        "alias": "minho",
+        "title": "Minho",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "mini_golf",
+        "title": "Mini Golf",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "mistingsystemservices",
+        "title": "Misting System Services",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "mobile_home_repair",
+        "title": "Mobile Home Repair",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE",
+            "NL",
+            "CA",
+            "BE"
+        ]
+    },
+    {
+        "alias": "mobiledentrepair",
+        "title": "Mobile Dent Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "mobilehomes",
+        "title": "Mobile Home Dealers",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "mobileparks",
+        "title": "Mobile Home Parks",
+        "parents": [
+            "realestate"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "mobilephonerepair",
+        "title": "Mobile Phone Repair",
+        "parents": [
+            "itservices"
+        ]
+    },
+    {
+        "alias": "mobilephones",
+        "title": "Mobile Phones",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "mobilityequipment",
+        "title": "Mobility Equipment Sales & Services",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "modern_australian",
+        "title": "Modern Australian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "AU"
+        ]
+    },
+    {
+        "alias": "modern_european",
+        "title": "Modern European",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "mohels",
+        "title": "Mohels",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "mongolian",
+        "title": "Mongolian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "PT",
+            "ES",
+            "FI"
+        ]
+    },
+    {
+        "alias": "montessori",
+        "title": "Montessori Schools",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "moroccan",
+        "title": "Moroccan",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "mortgagebrokers",
+        "title": "Mortgage Brokers",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "ES",
+            "BR",
+            "DK"
+        ]
+    },
+    {
+        "alias": "mortgagelenders",
+        "title": "Mortgage Lenders",
+        "parents": [
+            "financialservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "FR",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "mortuaryservices",
+        "title": "Mortuary Services",
+        "parents": [
+            "funeralservices"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "mosques",
+        "title": "Mosques",
+        "parents": [
+            "religiousorgs"
+        ]
+    },
+    {
+        "alias": "motodealers",
+        "title": "Motorsport Vehicle Dealers",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "TW",
+            "US",
+            "ES",
+            "SE",
+            "IT"
+        ]
+    },
+    {
+        "alias": "motorcycle_rental",
+        "title": "Motorcycle Rental",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "SG",
+            "ES",
+            "PT",
+            "US",
+            "FR",
+            "MX",
+            "BR",
+            "CZ",
+            "AU",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "motorcycledealers",
+        "title": "Motorcycle Dealers",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "motorcyclerepair",
+        "title": "Motorcycle Repair",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "motorcyclinggear",
+        "title": "Motorcycle Gear",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "GB",
+            "CA",
+            "NZ",
+            "IE"
+        ]
+    },
+    {
+        "alias": "motorepairs",
+        "title": "Motorsport Vehicle Repairs",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "TW",
+            "US",
+            "ES",
+            "SE",
+            "IT"
+        ]
+    },
+    {
+        "alias": "mountainbiking",
+        "title": "Mountain Biking",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "mountainhuts",
+        "title": "Mountain Huts",
+        "parents": [
+            "hotels"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "NZ",
+            "CH",
+            "AT",
+            "ES",
+            "US",
+            "FR",
+            "AR",
+            "CZ",
+            "PL",
+            "NO",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "movers",
+        "title": "Movers",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "movietheaters",
+        "title": "Cinema",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "muaythai",
+        "title": "Muay Thai",
+        "parents": [
+            "martialarts"
+        ]
+    },
+    {
+        "alias": "municipality",
+        "title": "Municipality",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "museums",
+        "title": "Museums",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "musicalinstrumentsandteachers",
+        "title": "Musical Instruments & Teachers",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "musicians",
+        "title": "Musicians",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "musicinstrumentservices",
+        "title": "Musical Instrument Services",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "musicproduction",
+        "title": "Music Production Services",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "musicvenues",
+        "title": "Music Venues",
+        "parents": [
+            "arts",
+            "nightlife"
+        ]
+    },
+    {
+        "alias": "musicvideo",
+        "title": "Music & DVDs",
+        "parents": [
+            "media"
+        ]
+    },
+    {
+        "alias": "mystics",
+        "title": "Mystics",
+        "parents": [
+            "psychic_astrology"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "nailtechnicians",
+        "title": "Nail Technicians",
+        "parents": [
+            "othersalons"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "FR",
+            "CH",
+            "BR",
+            "JP",
+            "AT"
+        ]
+    },
+    {
+        "alias": "nannys",
+        "title": "Nanny Services",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "SE",
+            "FI"
+        ]
+    },
+    {
+        "alias": "napoletana",
+        "title": "Napoletana",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "IT",
+            "FR",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "nasilemak",
+        "title": "Nasi Lemak",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "SG",
+            "MY"
+        ]
+    },
+    {
+        "alias": "naturalgassuppliers",
+        "title": "Natural Gas Suppliers",
+        "parents": [
+            "utilities"
+        ]
+    },
+    {
+        "alias": "naturopathic",
+        "title": "Naturopathic/Holistic",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "nephrologists",
+        "title": "Nephrologists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "neurologist",
+        "title": "Neurologist",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "neuropathologists",
+        "title": "Neuropathologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "neurotologists",
+        "title": "Neurotologists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "newamerican",
+        "title": "American (New)",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE",
+            "DK",
+            "GB",
+            "NO",
+            "IE"
+        ]
+    },
+    {
+        "alias": "newcanadian",
+        "title": "Canadian (New)",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "CA"
+        ]
+    },
+    {
+        "alias": "newmexican",
+        "title": "New Mexican Cuisine",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "newzealand",
+        "title": "New Zealand",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "NZ"
+        ]
+    },
+    {
+        "alias": "nicaraguan",
+        "title": "Nicaraguan",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "AR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "nicois",
+        "title": "Nicoise",
+        "parents": [
+            "french"
+        ],
+        "country_whitelist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "nightfood",
+        "title": "Night Food",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "SE",
+            "DK",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "nightlife",
+        "title": "Nightlife",
+        "parents": []
+    },
+    {
+        "alias": "nikkei",
+        "title": "Nikkei",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "ES",
+            "AR",
+            "MX",
+            "BR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "nonprofit",
+        "title": "Community Service/Non-Profit",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "noodles",
+        "title": "Noodles",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "FR",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "norcinerie",
+        "title": "Norcinerie",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "northeasternbrazilian",
+        "title": "Northeastern Brazilian",
+        "parents": [
+            "brazilian"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "northernbrazilian",
+        "title": "Northern Brazilian",
+        "parents": [
+            "brazilian"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "northerngerman",
+        "title": "Northern German",
+        "parents": [
+            "german"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "northernmexican",
+        "title": "Northern Mexican",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "norwegian",
+        "title": "Traditional Norwegian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "FR",
+            "NO"
+        ]
+    },
+    {
+        "alias": "notaries",
+        "title": "Notaries",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "NO"
+        ]
+    },
+    {
+        "alias": "nudist",
+        "title": "Nudist",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "AT",
+            "DK",
+            "BE",
+            "CZ",
+            "SE",
+            "GB",
+            "IE",
+            "US",
+            "PT",
+            "NL",
+            "FR",
+            "CA",
+            "BR",
+            "AU",
+            "PL",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "nursepractitioner",
+        "title": "Nurse Practitioner",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "nursingschools",
+        "title": "Nursing Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "nutritionists",
+        "title": "Nutritionists",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "nyonya",
+        "title": "Nyonya",
+        "parents": [
+            "malaysian"
+        ],
+        "country_whitelist": [
+            "MY",
+            "AU"
+        ]
+    },
+    {
+        "alias": "oaxacan",
+        "title": "Oaxacan",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "obgyn",
+        "title": "Obstetricians & Gynecologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "observatories",
+        "title": "Observatories",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "occupationaltherapy",
+        "title": "Occupational Therapy",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "CH",
+            "JP",
+            "SG",
+            "AT",
+            "TW",
+            "HK",
+            "CZ",
+            "SE",
+            "MY",
+            "PH",
+            "FR",
+            "PL",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "oden",
+        "title": "Oden",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "officecleaning",
+        "title": "Office Cleaning",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "officeequipment",
+        "title": "Office Equipment",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "officiants",
+        "title": "Officiants",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "oilchange",
+        "title": "Oil Change Stations",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "SE",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "okinawan",
+        "title": "Okinawan",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "okonomiyaki",
+        "title": "Okonomiyaki",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "oliveoil",
+        "title": "Olive Oil",
+        "parents": [
+            "gourmet"
+        ],
+        "country_whitelist": [
+            "ES",
+            "DE",
+            "US",
+            "FR",
+            "BE",
+            "AT"
+        ]
+    },
+    {
+        "alias": "oncologist",
+        "title": "Oncologist",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "onigiri",
+        "title": "Onigiri",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "opensandwiches",
+        "title": "Open Sandwiches",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "NO",
+            "DK",
+            "SE"
+        ]
+    },
+    {
+        "alias": "opera",
+        "title": "Opera & Ballet",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "opthamalogists",
+        "title": "Ophthalmologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "opticians",
+        "title": "Eyewear & Opticians",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "optometrists",
+        "title": "Optometrists",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "oralsurgeons",
+        "title": "Oral Surgeons",
+        "parents": [
+            "dentists"
+        ]
+    },
+    {
+        "alias": "organdonorservices",
+        "title": "Organ & Tissue Donor Services",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "organic_stores",
+        "title": "Organic Stores",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "oriental",
+        "title": "Oriental",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "PT",
+            "FR",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "orthodontists",
+        "title": "Orthodontists",
+        "parents": [
+            "dentists"
+        ]
+    },
+    {
+        "alias": "orthopedists",
+        "title": "Orthopedists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "orthotics",
+        "title": "Orthotics",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "ES",
+            "US",
+            "FR",
+            "DK",
+            "BR",
+            "CZ",
+            "AU",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "osteopathicphysicians",
+        "title": "Osteopathic Physicians",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "osteopaths",
+        "title": "Osteopaths",
+        "parents": [
+            "medcenters"
+        ],
+        "country_whitelist": [
+            "AU"
+        ]
+    },
+    {
+        "alias": "othersalons",
+        "title": "Nail Salons",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "otologists",
+        "title": "Otologists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "FR",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "ottomancuisine",
+        "title": "Ottoman Cuisine",
+        "parents": [
+            "turkish"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "outdoorfurniture",
+        "title": "Outdoor Furniture Stores",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "outdoorgear",
+        "title": "Outdoor Gear",
+        "parents": [
+            "sportgoods"
+        ]
+    },
+    {
+        "alias": "outdoormovies",
+        "title": "Outdoor Movies",
+        "parents": [
+            "movietheaters"
+        ],
+        "country_blacklist": [
+            "PL"
+        ]
+    },
+    {
+        "alias": "outlet_stores",
+        "title": "Outlet Stores",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "oxygenbars",
+        "title": "Oxygen Bars",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "oyakodon",
+        "title": "Oyakodon",
+        "parents": [
+            "donburi"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "pachinko",
+        "title": "Pachinko",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "packingservices",
+        "title": "Packing Services",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "MY",
+            "SG",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "FR",
+            "CA",
+            "BE",
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "packingsupplies",
+        "title": "Packing Supplies",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "SG",
+            "AT",
+            "DK",
+            "BE",
+            "CZ",
+            "GB",
+            "IE",
+            "US",
+            "PT",
+            "NL",
+            "FR",
+            "CA",
+            "BR",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "paddleboarding",
+        "title": "Paddleboarding",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "MY",
+            "GB",
+            "JP",
+            "TW",
+            "PH",
+            "HK",
+            "NL",
+            "CA",
+            "BE",
+            "IT"
+        ]
+    },
+    {
+        "alias": "painmanagement",
+        "title": "Pain Management",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "paintandsip",
+        "title": "Paint & Sip",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "US",
+            "HK"
+        ]
+    },
+    {
+        "alias": "paintball",
+        "title": "Paintball",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SG"
+        ]
+    },
+    {
+        "alias": "painters",
+        "title": "Painters",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "paintstores",
+        "title": "Paint Stores",
+        "parents": [
+            "homeandgarden"
+        ],
+        "country_blacklist": [
+            "TW",
+            "TR",
+            "PH",
+            "PT",
+            "HK",
+            "MY",
+            "FI"
+        ]
+    },
+    {
+        "alias": "paintyourownpottery",
+        "title": "Paint-Your-Own Pottery",
+        "parents": [
+            "artsandcrafts"
+        ],
+        "country_whitelist": [
+            "DE",
+            "MY",
+            "SG",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "CA"
+        ]
+    },
+    {
+        "alias": "pakistani",
+        "title": "Pakistani",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "palatine",
+        "title": "Palatine",
+        "parents": [
+            "german"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "panasian",
+        "title": "Pan Asian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "panzerotti",
+        "title": "Panzerotti",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "parasailing",
+        "title": "Parasailing",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "parentingclasses",
+        "title": "Parenting Classes",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "parking",
+        "title": "Parking",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "parklets",
+        "title": "Parklets",
+        "parents": [
+            "localflavor"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "parks",
+        "title": "Parks",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "parma",
+        "title": "Parma",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "AU"
+        ]
+    },
+    {
+        "alias": "partybikerentals",
+        "title": "Party Bike Rentals",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "ES",
+            "DE",
+            "US",
+            "NL",
+            "BE",
+            "IE"
+        ]
+    },
+    {
+        "alias": "partybusrentals",
+        "title": "Party Bus Rentals",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "MY",
+            "JP",
+            "IE",
+            "TW",
+            "ES",
+            "PH",
+            "HK",
+            "PT",
+            "FR",
+            "CA",
+            "MX",
+            "CZ",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "partycharacters",
+        "title": "Party Characters",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "partyequipmentrentals",
+        "title": "Party Equipment Rentals",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "TW",
+            "FI",
+            "HK"
+        ]
+    },
+    {
+        "alias": "partysupplies",
+        "title": "Party Supplies",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "passportvisaservices",
+        "title": "Passport & Visa Services",
+        "parents": [
+            "travelservices"
+        ]
+    },
+    {
+        "alias": "pastashops",
+        "title": "Pasta Shops",
+        "parents": [
+            "gourmet"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "US",
+            "NL",
+            "AR",
+            "DK",
+            "BE",
+            "CZ",
+            "AU",
+            "NO",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "patentlaw",
+        "title": "Patent Law",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "pathologists",
+        "title": "Pathologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "patiocoverings",
+        "title": "Patio Coverings",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT",
+            "NL",
+            "CA",
+            "BE",
+            "BR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "pawn",
+        "title": "Pawn Shops",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "BR"
+        ]
+    },
+    {
+        "alias": "paydayloans",
+        "title": "Check Cashing/Pay-day Loans",
+        "parents": [
+            "financialservices"
+        ],
+        "country_blacklist": [
+            "DE",
+            "NZ",
+            "CH",
+            "AT",
+            "ES",
+            "DK",
+            "CZ",
+            "IT"
+        ]
+    },
+    {
+        "alias": "payroll",
+        "title": "Payroll Services",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "TR",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "pediatric_dentists",
+        "title": "Pediatric Dentists",
+        "parents": [
+            "dentists"
+        ]
+    },
+    {
+        "alias": "pediatricians",
+        "title": "Pediatricians",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "pedicabs",
+        "title": "Pedicabs",
+        "parents": [
+            "transport"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "MY",
+            "CH",
+            "AT",
+            "US",
+            "PH",
+            "DK",
+            "NO"
+        ]
+    },
+    {
+        "alias": "pekinese",
+        "title": "Pekinese",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "HK",
+            "FR",
+            "MY",
+            "JP",
+            "SG",
+            "IT"
+        ]
+    },
+    {
+        "alias": "pensions",
+        "title": "Pensions",
+        "parents": [
+            "hotels"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "JP",
+            "AT",
+            "ES",
+            "DK",
+            "BR",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "perfume",
+        "title": "Perfume",
+        "parents": [
+            "shopping",
+            "beautysvc"
+        ],
+        "country_blacklist": [
+            "TR",
+            "CA",
+            "PL",
+            "SG",
+            "FI"
+        ]
+    },
+    {
+        "alias": "periodontists",
+        "title": "Periodontists",
+        "parents": [
+            "dentists"
+        ]
+    },
+    {
+        "alias": "permanentmakeup",
+        "title": "Permanent Makeup",
+        "parents": [
+            "beautysvc"
+        ],
+        "country_blacklist": [
+            "SG",
+            "NZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "persian",
+        "title": "Persian/Iranian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "personal_injury",
+        "title": "Personal Injury Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "personal_shopping",
+        "title": "Personal Shopping",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "ES",
+            "AR",
+            "MX",
+            "BR",
+            "CZ",
+            "CL"
+        ]
+    },
+    {
+        "alias": "personalassistants",
+        "title": "Personal Assistants",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "US",
+            "CZ",
+            "PT"
+        ]
+    },
+    {
+        "alias": "personalcare",
+        "title": "Personal Care Services",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US",
+            "NL",
+            "FR",
+            "DK",
+            "BE",
+            "BR",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "personalchefs",
+        "title": "Personal Chefs",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "peruvian",
+        "title": "Peruvian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "SG",
+            "TR",
+            "PT"
+        ]
+    },
+    {
+        "alias": "pest_control",
+        "title": "Pest Control",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "pet_sitting",
+        "title": "Pet Sitting",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "pet_training",
+        "title": "Pet Training",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "petadoption",
+        "title": "Pet Adoption",
+        "parents": [
+            "pets"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "petboarding",
+        "title": "Pet Boarding",
+        "parents": [
+            "pet_sitting"
+        ]
+    },
+    {
+        "alias": "petbreeders",
+        "title": "Pet Breeders",
+        "parents": [
+            "petservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "MY",
+            "SG",
+            "IE",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "AR",
+            "FI",
+            "MX",
+            "BR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "petcremation",
+        "title": "Pet Cremation Services",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "pethospice",
+        "title": "Pet Hospice",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "petinsurance",
+        "title": "Pet Insurance",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "petphotography",
+        "title": "Pet Photography",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "pets",
+        "title": "Pets",
+        "parents": []
+    },
+    {
+        "alias": "petservices",
+        "title": "Pet Services",
+        "parents": [
+            "pets"
+        ]
+    },
+    {
+        "alias": "petstore",
+        "title": "Pet Stores",
+        "parents": [
+            "pets"
+        ]
+    },
+    {
+        "alias": "pettingzoos",
+        "title": "Petting Zoos",
+        "parents": [
+            "zoos"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "GB",
+            "AT",
+            "ES",
+            "US",
+            "NL",
+            "DK",
+            "BE",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "pettransport",
+        "title": "Pet Transportation",
+        "parents": [
+            "petservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE"
+        ]
+    },
+    {
+        "alias": "petwasteremoval",
+        "title": "Pet Waste Removal",
+        "parents": [
+            "petservices"
+        ]
+    },
+    {
+        "alias": "pfcomercial",
+        "title": "PF/Comercial",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "pharmacy",
+        "title": "Pharmacy",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "phlebologists",
+        "title": "Phlebologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "photoboothrentals",
+        "title": "Photo Booth Rentals",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "JP",
+            "FI",
+            "HK"
+        ]
+    },
+    {
+        "alias": "photoclasses",
+        "title": "Photography Classes",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "photographers",
+        "title": "Photographers",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "photographystores",
+        "title": "Photography Stores & Services",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "physicaltherapy",
+        "title": "Physical Therapy",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "physicians",
+        "title": "Doctors",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "piadina",
+        "title": "Piadina",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "US",
+            "IT"
+        ]
+    },
+    {
+        "alias": "pianobars",
+        "title": "Piano Bars",
+        "parents": [
+            "nightlife"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "CH",
+            "SG",
+            "IE",
+            "AT",
+            "ES",
+            "BR",
+            "AU",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "pianoservices",
+        "title": "Piano Services",
+        "parents": [
+            "musicinstrumentservices"
+        ]
+    },
+    {
+        "alias": "pianostores",
+        "title": "Piano Stores",
+        "parents": [
+            "musicinstrumentservices"
+        ]
+    },
+    {
+        "alias": "pickyourown",
+        "title": "Pick Your Own Farms",
+        "parents": [
+            "farms"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "JP",
+            "AT",
+            "US",
+            "FR",
+            "DK",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "piemonte",
+        "title": "Piemonte",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "piercing",
+        "title": "Piercing",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "pierogis",
+        "title": "Pierogis",
+        "parents": [
+            "polish"
+        ],
+        "country_whitelist": [
+            "PL"
+        ]
+    },
+    {
+        "alias": "pilates",
+        "title": "Pilates",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "pita",
+        "title": "Pita",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "pizza",
+        "title": "Pizza",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "placentaencapsulation",
+        "title": "Placenta Encapsulations",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "FR",
+            "CH",
+            "CZ",
+            "PL",
+            "AT"
+        ]
+    },
+    {
+        "alias": "planetarium",
+        "title": "Planetarium",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "plasticsurgeons",
+        "title": "Plastic Surgeons",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "ES",
+            "CL"
+        ]
+    },
+    {
+        "alias": "playgrounds",
+        "title": "Playgrounds",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "playsets",
+        "title": "Playsets",
+        "parents": [
+            "homeandgarden"
+        ]
+    },
+    {
+        "alias": "plumbing",
+        "title": "Plumbing",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "plus_size_fashion",
+        "title": "Plus Size Fashion",
+        "parents": [
+            "fashion"
+        ],
+        "country_blacklist": [
+            "TR",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "HK",
+            "AR",
+            "CA",
+            "MX",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "podiatrists",
+        "title": "Podiatrists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "poke",
+        "title": "Poke",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "US",
+            "SE",
+            "NL",
+            "FR",
+            "CA",
+            "BE"
+        ]
+    },
+    {
+        "alias": "poledancingclasses",
+        "title": "Pole Dancing Classes",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_blacklist": [
+            "TR",
+            "CH",
+            "GB",
+            "IE",
+            "AT",
+            "ES",
+            "PT",
+            "AR",
+            "CA",
+            "MX",
+            "BE",
+            "PL",
+            "CL"
+        ]
+    },
+    {
+        "alias": "policedepartments",
+        "title": "Police Departments",
+        "parents": [
+            "publicservicesgovt"
+        ]
+    },
+    {
+        "alias": "polish",
+        "title": "Polish",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "SG",
+            "FI"
+        ]
+    },
+    {
+        "alias": "polynesian",
+        "title": "Polynesian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "poolbilliards",
+        "title": "Pool & Billiards",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "DE",
+            "SE",
+            "CH",
+            "CL",
+            "AT",
+            "ES",
+            "AR",
+            "MX",
+            "CZ",
+            "PL",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "poolcleaners",
+        "title": "Pool Cleaners",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "NO",
+            "DK"
+        ]
+    },
+    {
+        "alias": "poolhalls",
+        "title": "Pool Halls",
+        "parents": [
+            "nightlife"
+        ]
+    },
+    {
+        "alias": "poolservice",
+        "title": "Pool & Hot Tub Service",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "popcorn",
+        "title": "Popcorn Shops",
+        "parents": [
+            "gourmet"
+        ],
+        "country_whitelist": [
+            "US",
+            "GB",
+            "JP"
+        ]
+    },
+    {
+        "alias": "popuprestaurants",
+        "title": "Pop-Up Restaurants",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "SG",
+            "TW",
+            "HK",
+            "DK",
+            "BE",
+            "SE",
+            "MY",
+            "GB",
+            "IE",
+            "US",
+            "PH",
+            "NL",
+            "FR",
+            "CA",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "popupshops",
+        "title": "Pop-up Shops",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "portuguese",
+        "title": "Portuguese",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "postoffices",
+        "title": "Post Offices",
+        "parents": [
+            "publicservicesgovt"
+        ]
+    },
+    {
+        "alias": "postpartumcare",
+        "title": "Postpartum Care",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "TW",
+            "HK",
+            "MY",
+            "JP",
+            "PL"
+        ]
+    },
+    {
+        "alias": "potatoes",
+        "title": "Potatoes",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "CH",
+            "DE",
+            "AU",
+            "AT"
+        ]
+    },
+    {
+        "alias": "poutineries",
+        "title": "Poutineries",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "powdercoating",
+        "title": "Powder Coating",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "prenatal",
+        "title": "Prenatal/Perinatal Care",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "MY",
+            "CH",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "CA",
+            "PL"
+        ]
+    },
+    {
+        "alias": "preschools",
+        "title": "Preschools",
+        "parents": [
+            "education"
+        ],
+        "country_blacklist": [
+            "DK"
+        ]
+    },
+    {
+        "alias": "pressurewashers",
+        "title": "Pressure Washers",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "pretzels",
+        "title": "Pretzels",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "PT",
+            "DE",
+            "US",
+            "CH"
+        ]
+    },
+    {
+        "alias": "preventivemedicine",
+        "title": "Preventive Medicine",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "printmedia",
+        "title": "Print Media",
+        "parents": [
+            "massmedia"
+        ]
+    },
+    {
+        "alias": "privateinvestigation",
+        "title": "Private Investigation",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "privatejetcharter",
+        "title": "Private Jet Charter",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "privateschools",
+        "title": "Private Schools",
+        "parents": [
+            "education"
+        ],
+        "country_whitelist": [
+            "SE",
+            "NZ",
+            "ES",
+            "PT",
+            "US",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "CZ",
+            "AU",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "privatetutors",
+        "title": "Private Tutors",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "processservers",
+        "title": "Process Servers",
+        "parents": [
+            "legalservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "proctologist",
+        "title": "Proctologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "productdesign",
+        "title": "Product Design",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "PH",
+            "NL",
+            "FR",
+            "CA",
+            "DK",
+            "BE",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "professional",
+        "title": "Professional Services",
+        "parents": []
+    },
+    {
+        "alias": "propane",
+        "title": "Propane",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "NZ",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "propertymgmt",
+        "title": "Property Management",
+        "parents": [
+            "realestate"
+        ]
+    },
+    {
+        "alias": "props",
+        "title": "Props",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "BE",
+            "US"
+        ]
+    },
+    {
+        "alias": "prosthetics",
+        "title": "Prosthetics",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "IT",
+            "US",
+            "ES",
+            "AU"
+        ]
+    },
+    {
+        "alias": "prosthodontists",
+        "title": "Prosthodontists",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "IT",
+            "US",
+            "ES"
+        ]
+    },
+    {
+        "alias": "provencal",
+        "title": "Provencal",
+        "parents": [
+            "french"
+        ],
+        "country_whitelist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "psychiatrists",
+        "title": "Psychiatrists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "psychic_astrology",
+        "title": "Supernatural Readings",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "psychicmediums",
+        "title": "Psychic Mediums",
+        "parents": [
+            "psychic_astrology"
+        ],
+        "country_blacklist": [
+            "PL"
+        ]
+    },
+    {
+        "alias": "psychics",
+        "title": "Psychics",
+        "parents": [
+            "psychic_astrology"
+        ]
+    },
+    {
+        "alias": "psychoanalysts",
+        "title": "Psychoanalysts",
+        "parents": [
+            "c_and_mh"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "NL",
+            "FR",
+            "AR",
+            "MX",
+            "BE",
+            "BR",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "psychologists",
+        "title": "Psychologists",
+        "parents": [
+            "c_and_mh"
+        ],
+        "country_blacklist": [
+            "HK",
+            "GB",
+            "JP",
+            "PL",
+            "SG",
+            "IE"
+        ]
+    },
+    {
+        "alias": "psychotechnicaltests",
+        "title": "Psychotechnical Tests",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "BR",
+            "ES"
+        ]
+    },
+    {
+        "alias": "psychotherapists",
+        "title": "Psychotherapists",
+        "parents": [
+            "c_and_mh"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "SG",
+            "AT",
+            "FR",
+            "DK",
+            "BR",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "pubfood",
+        "title": "Pub Food",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "AU"
+        ]
+    },
+    {
+        "alias": "publicadjusters",
+        "title": "Public Adjusters",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "publicart",
+        "title": "Public Art",
+        "parents": [
+            "localflavor"
+        ]
+    },
+    {
+        "alias": "publicmarkets",
+        "title": "Public Markets",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "publicplazas",
+        "title": "Public Plazas",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "AU"
+        ]
+    },
+    {
+        "alias": "publicrelations",
+        "title": "Public Relations",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "publicservicesgovt",
+        "title": "Public Services & Government",
+        "parents": []
+    },
+    {
+        "alias": "publictransport",
+        "title": "Public Transportation",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "pubs",
+        "title": "Pubs",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "pueblan",
+        "title": "Pueblan",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "puertorican",
+        "title": "Puerto Rican",
+        "parents": [
+            "caribbean"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "pulmonologist",
+        "title": "Pulmonologist",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "pulquerias",
+        "title": "Pulquerias",
+        "parents": [
+            "bars"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "pumpkinpatches",
+        "title": "Pumpkin Patches",
+        "parents": [
+            "homeandgarden"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "qigong",
+        "title": "Qi Gong",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "races",
+        "title": "Races & Competitions",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "JP",
+            "IE",
+            "TW",
+            "ES",
+            "PH",
+            "HK",
+            "PT",
+            "AR",
+            "CA",
+            "FI",
+            "MX",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "racetracks",
+        "title": "Race Tracks",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "BR",
+            "SG",
+            "IE",
+            "AT"
+        ]
+    },
+    {
+        "alias": "racingexperience",
+        "title": "Racing Experience",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "FR",
+            "US",
+            "SE"
+        ]
+    },
+    {
+        "alias": "radiologists",
+        "title": "Radiologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "radiostations",
+        "title": "Radio Stations",
+        "parents": [
+            "massmedia"
+        ]
+    },
+    {
+        "alias": "rafting",
+        "title": "Rafting/Kayaking",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "ramen",
+        "title": "Ramen",
+        "parents": [
+            "japanese"
+        ]
+    },
+    {
+        "alias": "ranches",
+        "title": "Ranches",
+        "parents": [
+            "farms"
+        ],
+        "country_whitelist": [
+            "ES",
+            "US",
+            "AR",
+            "MX",
+            "CZ",
+            "CL"
+        ]
+    },
+    {
+        "alias": "raw_food",
+        "title": "Live/Raw Food",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "realestate",
+        "title": "Real Estate",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "realestateagents",
+        "title": "Real Estate Agents",
+        "parents": [
+            "realestate"
+        ]
+    },
+    {
+        "alias": "realestatelawyers",
+        "title": "Real Estate Law",
+        "parents": [
+            "lawyers"
+        ]
+    },
+    {
+        "alias": "realestatesvcs",
+        "title": "Real Estate Services",
+        "parents": [
+            "realestate"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "record_labels",
+        "title": "Record Labels",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "PT",
+            "DK",
+            "BR",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "recording_studios",
+        "title": "Recording & Rehearsal Studios",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "recreation",
+        "title": "Recreation Centers",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "recyclingcenter",
+        "title": "Recycling Center",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "refinishing",
+        "title": "Refinishing Services",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "reflexology",
+        "title": "Reflexology",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "PL",
+            "SE",
+            "TR",
+            "FI"
+        ]
+    },
+    {
+        "alias": "registrationservices",
+        "title": "Registration Services",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "ES",
+            "AR",
+            "DK",
+            "MX",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "registry_office",
+        "title": "Registry Office",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "PT",
+            "NL",
+            "DK",
+            "BE",
+            "BR",
+            "CZ",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "rehabilitation_center",
+        "title": "Rehabilitation Center",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "CH",
+            "SG",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "FR"
+        ]
+    },
+    {
+        "alias": "reiki",
+        "title": "Reiki",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "HK",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "religiousitems",
+        "title": "Religious Items",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "religiousorgs",
+        "title": "Religious Organizations",
+        "parents": []
+    },
+    {
+        "alias": "religiousschools",
+        "title": "Religious Schools",
+        "parents": [
+            "education"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "MY",
+            "ES",
+            "PH",
+            "PT",
+            "US",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "CZ",
+            "AU",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "rentfurniture",
+        "title": "Furniture Rental",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "JP",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "AR",
+            "CA",
+            "MX",
+            "BE",
+            "AU",
+            "CL"
+        ]
+    },
+    {
+        "alias": "reptileshops",
+        "title": "Reptile Shops",
+        "parents": [
+            "petstore"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "JP",
+            "ES",
+            "US",
+            "NL",
+            "DK",
+            "BE",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "residences",
+        "title": "Residences",
+        "parents": [
+            "hotels"
+        ],
+        "country_whitelist": [
+            "SG",
+            "IT",
+            "ES",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "resorts",
+        "title": "Resorts",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "restaurants",
+        "title": "Restaurants",
+        "parents": []
+    },
+    {
+        "alias": "reststops",
+        "title": "Rest Stops",
+        "parents": [
+            "hotels"
+        ]
+    },
+    {
+        "alias": "retinaspecialists",
+        "title": "Retina Specialists",
+        "parents": [
+            "opthamalogists"
+        ],
+        "country_blacklist": [
+            "FR",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "retirement_homes",
+        "title": "Retirement Homes",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "reunion",
+        "title": "Reunion",
+        "parents": [
+            "french"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "AT",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "AU",
+            "PL",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "reupholstery",
+        "title": "Furniture Reupholstery",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "rhematologists",
+        "title": "Rheumatologists",
+        "parents": [
+            "physicians"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "TW",
+            "HK",
+            "CA",
+            "AU",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "rhinelandian",
+        "title": "Rhinelandian",
+        "parents": [
+            "german"
+        ],
+        "country_whitelist": [
+            "DE"
+        ]
+    },
+    {
+        "alias": "ribatejo",
+        "title": "Ribatejo",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "riceshop",
+        "title": "Rice",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "JP"
+        ]
+    },
+    {
+        "alias": "roadsideassist",
+        "title": "Roadside Assistance",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "PT",
+            "HK",
+            "FR",
+            "BR",
+            "FI"
+        ]
+    },
+    {
+        "alias": "robatayaki",
+        "title": "Robatayaki",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP",
+            "HK"
+        ]
+    },
+    {
+        "alias": "rock_climbing",
+        "title": "Rock Climbing",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "rodeo",
+        "title": "Rodeo",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "rodizios",
+        "title": "Rodizios",
+        "parents": [
+            "brazilian"
+        ],
+        "country_whitelist": [
+            "AR",
+            "PT",
+            "BR"
+        ]
+    },
+    {
+        "alias": "roman",
+        "title": "Roman",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "JP",
+            "IT"
+        ]
+    },
+    {
+        "alias": "romanian",
+        "title": "Romanian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "ES",
+            "FR",
+            "BE",
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "roofing",
+        "title": "Roofing",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "roofinspectors",
+        "title": "Roof Inspectors",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "rotisserie_chicken",
+        "title": "Rotisserie Chicken",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "ES",
+            "PT",
+            "NL",
+            "FR",
+            "AR",
+            "MX",
+            "BE",
+            "BR",
+            "AU",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "rugs",
+        "title": "Rugs",
+        "parents": [
+            "homeandgarden"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "JP",
+            "IE",
+            "AT",
+            "HK",
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "russian",
+        "title": "Russian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "rv_dealers",
+        "title": "RV Dealers",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "MY",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "AR",
+            "MX",
+            "AU",
+            "CL"
+        ]
+    },
+    {
+        "alias": "rvparks",
+        "title": "RV Parks",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "SG",
+            "AT",
+            "ES",
+            "DK",
+            "MX",
+            "BE",
+            "CZ",
+            "CL",
+            "SE",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "FR",
+            "AR",
+            "CA",
+            "PL",
+            "AU",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "rvrental",
+        "title": "RV Rental",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_blacklist": [
+            "SG"
+        ]
+    },
+    {
+        "alias": "rvrepair",
+        "title": "RV Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "ryokan",
+        "title": "Ryokan",
+        "parents": [
+            "hotels"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "safestores",
+        "title": "Safe Stores",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "safetyequipment",
+        "title": "Safety Equipment",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "sailing",
+        "title": "Sailing",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "sakebars",
+        "title": "Sake Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "salad",
+        "title": "Salad",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "salumerie",
+        "title": "Salumerie",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "AR",
+            "MX",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "salvadoran",
+        "title": "Salvadoran",
+        "parents": [
+            "latin"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "sambaschools",
+        "title": "Samba Schools",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "SE",
+            "BR",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "sandblasting",
+        "title": "Sandblasting",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "ES",
+            "US",
+            "NL",
+            "BE",
+            "BR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "sandwiches",
+        "title": "Sandwiches",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "sardinian",
+        "title": "Sardinian",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "US",
+            "IT"
+        ]
+    },
+    {
+        "alias": "saunainstallation",
+        "title": "Sauna Installation & Repair",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "CA",
+            "DK",
+            "CZ",
+            "AU",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "saunas",
+        "title": "Saunas",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "MY",
+            "SG",
+            "ES",
+            "PH",
+            "CA",
+            "AU",
+            "PL"
+        ]
+    },
+    {
+        "alias": "scandinavian",
+        "title": "Scandinavian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "scandinaviandesign",
+        "title": "Scandinavian Design",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "SE",
+            "NO",
+            "DK",
+            "FI"
+        ]
+    },
+    {
+        "alias": "scavengerhunts",
+        "title": "Scavenger Hunts",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "schnitzel",
+        "title": "Schnitzel",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "PL",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "scooterrentals",
+        "title": "Scooter Rentals",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "scootertours",
+        "title": "Scooter Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "scottish",
+        "title": "Scottish",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US",
+            "DE",
+            "CA",
+            "CH",
+            "GB",
+            "IE",
+            "AT"
+        ]
+    },
+    {
+        "alias": "screen_printing_tshirt_printing",
+        "title": "Screen Printing/T-Shirt Printing",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "HK",
+            "CA",
+            "CZ",
+            "PL",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "screenprinting",
+        "title": "Screen Printing",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "scuba",
+        "title": "Scuba Diving",
+        "parents": [
+            "diving"
+        ]
+    },
+    {
+        "alias": "seafood",
+        "title": "Seafood",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "seafoodmarkets",
+        "title": "Seafood Markets",
+        "parents": [
+            "gourmet"
+        ]
+    },
+    {
+        "alias": "seasonaldecorservices",
+        "title": "Holiday Decorating Services",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "CH",
+            "JP",
+            "AT",
+            "NL",
+            "FR",
+            "DK",
+            "BE",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "security",
+        "title": "Security Services",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "NZ"
+        ]
+    },
+    {
+        "alias": "securitysystems",
+        "title": "Security Systems",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "selfdefenseclasses",
+        "title": "Self-defense Classes",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "selfstorage",
+        "title": "Self Storage",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "senegalese",
+        "title": "Senegalese",
+        "parents": [
+            "african"
+        ],
+        "country_whitelist": [
+            "US",
+            "FR",
+            "CA",
+            "BE",
+            "IT"
+        ]
+    },
+    {
+        "alias": "seniorcenters",
+        "title": "Senior Centers",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "septicservices",
+        "title": "Septic Services",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "PT",
+            "NL",
+            "CA",
+            "DK",
+            "BE",
+            "BR",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "serbocroatian",
+        "title": "Serbo Croatian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "CH",
+            "AT",
+            "FR",
+            "AR",
+            "BE",
+            "CZ",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "service_stations",
+        "title": "Service Stations",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "MY",
+            "JP",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "FR",
+            "DK",
+            "BR",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "servicestations",
+        "title": "Gas Stations",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "sessionphotography",
+        "title": "Session Photography",
+        "parents": [
+            "photographers"
+        ]
+    },
+    {
+        "alias": "sewingalterations",
+        "title": "Sewing & Alterations",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "sextherapists",
+        "title": "Sex Therapists",
+        "parents": [
+            "c_and_mh"
+        ]
+    },
+    {
+        "alias": "shanghainese",
+        "title": "Shanghainese",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "SE",
+            "MY",
+            "JP",
+            "SG",
+            "TW",
+            "US",
+            "HK",
+            "FR",
+            "BE",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "sharedofficespaces",
+        "title": "Shared Office Spaces",
+        "parents": [
+            "realestate"
+        ]
+    },
+    {
+        "alias": "sharedtaxis",
+        "title": "Shared Taxis",
+        "parents": [
+            "transport"
+        ],
+        "country_whitelist": [
+            "TR",
+            "SE",
+            "PH",
+            "DK",
+            "BR",
+            "NO"
+        ]
+    },
+    {
+        "alias": "shavedice",
+        "title": "Shaved Ice",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "JP",
+            "SG",
+            "TW",
+            "US",
+            "AR",
+            "MX",
+            "CZ",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "shavedsnow",
+        "title": "Shaved Snow",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "TW",
+            "US",
+            "HK",
+            "CA",
+            "MY",
+            "SG"
+        ]
+    },
+    {
+        "alias": "shipping_centers",
+        "title": "Shipping Centers",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "NO",
+            "SE"
+        ]
+    },
+    {
+        "alias": "shoerepair",
+        "title": "Shoe Repair",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "shoes",
+        "title": "Shoe Stores",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "shoeshine",
+        "title": "Shoe Shine",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "NL",
+            "BE"
+        ]
+    },
+    {
+        "alias": "shopping",
+        "title": "Shopping",
+        "parents": []
+    },
+    {
+        "alias": "shoppingcenters",
+        "title": "Shopping Centers",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "shoppingpassages",
+        "title": "Shopping Passages",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "shredding",
+        "title": "Shredding Services",
+        "parents": [
+            "professional"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "shrines",
+        "title": "Shrines",
+        "parents": [
+            "religiousorgs"
+        ],
+        "country_whitelist": [
+            "ES",
+            "AR",
+            "MX",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "shutters",
+        "title": "Shutters",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "sicilian",
+        "title": "Sicilian",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "US",
+            "FR",
+            "CZ",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "signature_cuisine",
+        "title": "Signature Cuisine",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "SE",
+            "ES",
+            "PT",
+            "AR",
+            "DK",
+            "MX",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "signmaking",
+        "title": "Signmaking",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "sikhtemples",
+        "title": "Sikh Temples",
+        "parents": [
+            "religiousorgs"
+        ]
+    },
+    {
+        "alias": "silentdisco",
+        "title": "Silent Disco",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "singaporean",
+        "title": "Singaporean",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "PT",
+            "DK",
+            "CZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "skate_parks",
+        "title": "Skate Parks",
+        "parents": [
+            "parks"
+        ]
+    },
+    {
+        "alias": "skateshops",
+        "title": "Skate Shops",
+        "parents": [
+            "sportgoods"
+        ]
+    },
+    {
+        "alias": "skatingrinks",
+        "title": "Skating Rinks",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "skiing",
+        "title": "Skiing",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "FR",
+            "MX",
+            "BR",
+            "AU",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "skillednursing",
+        "title": "Skilled Nursing",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "skincare",
+        "title": "Skin Care",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "skiresorts",
+        "title": "Ski Resorts",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_blacklist": [
+            "MX",
+            "BR",
+            "SG",
+            "DK"
+        ]
+    },
+    {
+        "alias": "skischools",
+        "title": "Ski Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "skishops",
+        "title": "Ski & Snowboard Shops",
+        "parents": [
+            "sportgoods"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "SG",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "DK",
+            "MX",
+            "BR"
+        ]
+    },
+    {
+        "alias": "skydiving",
+        "title": "Skydiving",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "sledding",
+        "title": "Sledding",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "AT",
+            "US",
+            "PT",
+            "CA",
+            "CZ",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "sleepspecialists",
+        "title": "Sleep Specialists",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "sleepwear",
+        "title": "Sleepwear",
+        "parents": [
+            "fashion"
+        ],
+        "country_whitelist": [
+            "PT",
+            "AU"
+        ]
+    },
+    {
+        "alias": "slovakian",
+        "title": "Slovakian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "GB",
+            "IE",
+            "US",
+            "FR",
+            "CA",
+            "BE",
+            "CZ",
+            "AU",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "smog_check_stations",
+        "title": "Smog Check Stations",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "SE",
+            "NO",
+            "DK",
+            "FI"
+        ]
+    },
+    {
+        "alias": "smokehouse",
+        "title": "Smokehouse",
+        "parents": [
+            "food"
+        ],
+        "country_blacklist": [
+            "TR",
+            "FR",
+            "AR",
+            "MX",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "smokingareas",
+        "title": "Smoking Areas",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "snorkeling",
+        "title": "Snorkeling",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "snowremoval",
+        "title": "Snow Removal",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "MX",
+            "BR",
+            "NZ",
+            "HK"
+        ]
+    },
+    {
+        "alias": "snuggleservices",
+        "title": "Snuggle Services",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "JP"
+        ]
+    },
+    {
+        "alias": "soba",
+        "title": "Soba",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "social_clubs",
+        "title": "Social Clubs",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "socialsecuritylaw",
+        "title": "Social Security Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_blacklist": [
+            "CZ",
+            "PL"
+        ]
+    },
+    {
+        "alias": "softwaredevelopment",
+        "title": "Software Development",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "solarinstallation",
+        "title": "Solar Installation",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "solarpanelcleaning",
+        "title": "Solar Panel Cleaning",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "sommelierservices",
+        "title": "Sommelier Services",
+        "parents": [
+            "eventservices"
+        ],
+        "country_blacklist": [
+            "FR"
+        ]
+    },
+    {
+        "alias": "sophrologists",
+        "title": "Sophrologists",
+        "parents": [
+            "c_and_mh"
+        ],
+        "country_whitelist": [
+            "PL",
+            "BE",
+            "CZ",
+            "FR"
+        ]
+    },
+    {
+        "alias": "soulfood",
+        "title": "Soul Food",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "SE",
+            "GB",
+            "IE",
+            "ES",
+            "US",
+            "NL",
+            "CA",
+            "PL",
+            "NO"
+        ]
+    },
+    {
+        "alias": "soup",
+        "title": "Soup",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "southafrican",
+        "title": "South African",
+        "parents": [
+            "african"
+        ],
+        "country_whitelist": [
+            "US",
+            "FR",
+            "CA",
+            "BE",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "southern",
+        "title": "Southern",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "SE",
+            "NZ",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "CA",
+            "PL"
+        ]
+    },
+    {
+        "alias": "souvenirs",
+        "title": "Souvenir Shops",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "SG",
+            "CA"
+        ]
+    },
+    {
+        "alias": "spanish",
+        "title": "Spanish",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "spas",
+        "title": "Day Spas",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "speakeasies",
+        "title": "Speakeasies",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "TR",
+            "FR",
+            "DK",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "specialbikes",
+        "title": "Special Bikes",
+        "parents": [
+            "bicycles"
+        ],
+        "country_whitelist": [
+            "DK",
+            "PT"
+        ]
+    },
+    {
+        "alias": "specialed",
+        "title": "Special Education",
+        "parents": [
+            "education"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "specialtyschools",
+        "title": "Specialty Schools",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "speech_therapists",
+        "title": "Speech Therapists",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "speechtraining",
+        "title": "Speech Training",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "spermclinic",
+        "title": "Sperm Clinic",
+        "parents": [
+            "health"
+        ],
+        "country_whitelist": [
+            "DE",
+            "ES",
+            "US",
+            "NL",
+            "FR",
+            "AR",
+            "DK",
+            "MX",
+            "BE",
+            "NO",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "spinesurgeons",
+        "title": "Spine Surgeons",
+        "parents": [
+            "physicians"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "spiritism",
+        "title": "Spiritism",
+        "parents": [
+            "religiousorgs"
+        ],
+        "country_whitelist": [
+            "BR"
+        ]
+    },
+    {
+        "alias": "spiritual_shop",
+        "title": "Spiritual Shop",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "sport_equipment_hire",
+        "title": "Sport Equipment Hire",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "AR",
+            "DK",
+            "MX",
+            "CZ",
+            "AU",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "sportgoods",
+        "title": "Sporting Goods",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "sports_clubs",
+        "title": "Sports Clubs",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "sportsbars",
+        "title": "Sports Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "sportsmed",
+        "title": "Sports Medicine",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "sportspsychologists",
+        "title": "Sports Psychologists",
+        "parents": [
+            "c_and_mh"
+        ],
+        "country_whitelist": [
+            "SG",
+            "US",
+            "NZ",
+            "IT"
+        ]
+    },
+    {
+        "alias": "sportsteams",
+        "title": "Professional Sports Teams",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "sportswear",
+        "title": "Sports Wear",
+        "parents": [
+            "fashion",
+            "sportgoods"
+        ]
+    },
+    {
+        "alias": "spraytanning",
+        "title": "Spray Tanning",
+        "parents": [
+            "tanning"
+        ],
+        "country_blacklist": [
+            "SE",
+            "CA",
+            "BR",
+            "PL",
+            "IE"
+        ]
+    },
+    {
+        "alias": "squash",
+        "title": "Squash",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "SG",
+            "BR",
+            "NZ",
+            "PT"
+        ]
+    },
+    {
+        "alias": "srilankan",
+        "title": "Sri Lankan",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "stadiumsarenas",
+        "title": "Stadiums & Arenas",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "stationery",
+        "title": "Cards & Stationery",
+        "parents": [
+            "artsandcrafts",
+            "eventservices",
+            "flowers"
+        ]
+    },
+    {
+        "alias": "steak",
+        "title": "Steakhouses",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "stereo_installation",
+        "title": "Car Stereo Installation",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "DK",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "stockings",
+        "title": "Stockings",
+        "parents": [
+            "fashion"
+        ],
+        "country_whitelist": [
+            "DE",
+            "PT",
+            "NL",
+            "CH",
+            "BE",
+            "CZ",
+            "AT"
+        ]
+    },
+    {
+        "alias": "streetart",
+        "title": "Street Art",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "US",
+            "CA",
+            "FI"
+        ]
+    },
+    {
+        "alias": "streetvendors",
+        "title": "Street Vendors",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "stripclubs",
+        "title": "Strip Clubs",
+        "parents": [
+            "adultentertainment"
+        ]
+    },
+    {
+        "alias": "stripteasedancers",
+        "title": "Striptease Dancers",
+        "parents": [
+            "adultentertainment"
+        ]
+    },
+    {
+        "alias": "structuralengineers",
+        "title": "Structural Engineers",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "stucco",
+        "title": "Stucco Services",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "studiotaping",
+        "title": "Studio Taping",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "NL",
+            "BE",
+            "US"
+        ]
+    },
+    {
+        "alias": "sud_ouest",
+        "title": "French Southwest",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "BE",
+            "FR"
+        ]
+    },
+    {
+        "alias": "sugaring",
+        "title": "Sugaring",
+        "parents": [
+            "hairremoval"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "US",
+            "DK",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "sugarshacks",
+        "title": "Sugar Shacks",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "CA"
+        ]
+    },
+    {
+        "alias": "sukiyaki",
+        "title": "Sukiyaki",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "summer_camps",
+        "title": "Summer Camps",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "sunglasses",
+        "title": "Sunglasses",
+        "parents": [
+            "opticians"
+        ]
+    },
+    {
+        "alias": "supperclubs",
+        "title": "Supper Clubs",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US",
+            "GB",
+            "CA",
+            "ES"
+        ]
+    },
+    {
+        "alias": "suppliesrestaurant",
+        "title": "Restaurant Supplies",
+        "parents": [
+            "wholesalers"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "SG",
+            "AT",
+            "ES",
+            "DK",
+            "MX",
+            "BE",
+            "CL",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "AR",
+            "CA",
+            "PL",
+            "AU",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "surfing",
+        "title": "Surfing",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "NZ",
+            "JP",
+            "ES",
+            "PT",
+            "US",
+            "NL",
+            "FR",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "surflifesaving",
+        "title": "Surf Lifesaving",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "ES",
+            "PT",
+            "AR",
+            "MX",
+            "BR",
+            "AU",
+            "CL"
+        ]
+    },
+    {
+        "alias": "surfschools",
+        "title": "Surf Schools",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "surfshop",
+        "title": "Surf Shop",
+        "parents": [
+            "fashion"
+        ],
+        "country_blacklist": [
+            "SE",
+            "SG",
+            "IE",
+            "NL",
+            "FR",
+            "CA",
+            "BE",
+            "BR",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "surgeons",
+        "title": "Surgeons",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "sushi",
+        "title": "Sushi Bars",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "swabian",
+        "title": "Swabian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "swedish",
+        "title": "Swedish",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "SE"
+        ]
+    },
+    {
+        "alias": "swimminglessons",
+        "title": "Swimming Lessons/Schools",
+        "parents": [
+            "specialtyschools",
+            "fitness"
+        ]
+    },
+    {
+        "alias": "swimmingpools",
+        "title": "Swimming Pools",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "swimwear",
+        "title": "Swimwear",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "swissfood",
+        "title": "Swiss Food",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "ES",
+            "DE",
+            "AR",
+            "CH",
+            "MX",
+            "CZ",
+            "CL"
+        ]
+    },
+    {
+        "alias": "synagogues",
+        "title": "Synagogues",
+        "parents": [
+            "religiousorgs"
+        ]
+    },
+    {
+        "alias": "syrian",
+        "title": "Syrian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "szechuan",
+        "title": "Szechuan",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "MY",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "TW",
+            "US",
+            "HK",
+            "FR",
+            "AU"
+        ]
+    },
+    {
+        "alias": "tabac",
+        "title": "Tabac",
+        "parents": [
+            "bars"
+        ],
+        "country_whitelist": [
+            "ES",
+            "FR",
+            "BE",
+            "CZ",
+            "IT"
+        ]
+    },
+    {
+        "alias": "tabernas",
+        "title": "Tabernas",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "ES",
+            "PT"
+        ]
+    },
+    {
+        "alias": "tablaoflamenco",
+        "title": "Tablao Flamenco",
+        "parents": [
+            "arts"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "AR",
+            "MX",
+            "CL"
+        ]
+    },
+    {
+        "alias": "tabletopgames",
+        "title": "Tabletop Games",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "tableware",
+        "title": "Tableware",
+        "parents": [
+            "homeandgarden"
+        ],
+        "country_whitelist": [
+            "DE",
+            "CH",
+            "AT",
+            "US",
+            "PT",
+            "NL",
+            "FR",
+            "AR",
+            "DK",
+            "MX",
+            "BE",
+            "BR",
+            "CZ",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "tacos",
+        "title": "Tacos",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX",
+            "US"
+        ]
+    },
+    {
+        "alias": "taekwondo",
+        "title": "Taekwondo",
+        "parents": [
+            "martialarts"
+        ]
+    },
+    {
+        "alias": "taichi",
+        "title": "Tai Chi",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "taiwanese",
+        "title": "Taiwanese",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "PT",
+            "CZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "taiyaki",
+        "title": "Taiyaki",
+        "parents": [
+            "jpsweets"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "takoyaki",
+        "title": "Takoyaki",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "talentagencies",
+        "title": "Talent Agencies",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "CH",
+            "GB",
+            "SG",
+            "IE",
+            "AT",
+            "HK",
+            "CA",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "tamales",
+        "title": "Tamales",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "tanning",
+        "title": "Tanning",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "tanningbeds",
+        "title": "Tanning Beds",
+        "parents": [
+            "tanning"
+        ],
+        "country_blacklist": [
+            "PL",
+            "SE",
+            "BR",
+            "FI"
+        ]
+    },
+    {
+        "alias": "taoisttemples",
+        "title": "Taoist Temples",
+        "parents": [
+            "religiousorgs"
+        ],
+        "country_whitelist": [
+            "TW",
+            "HK"
+        ]
+    },
+    {
+        "alias": "tapas",
+        "title": "Tapas Bars",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "SG",
+            "FI",
+            "AU"
+        ]
+    },
+    {
+        "alias": "tapasmallplates",
+        "title": "Tapas/Small Plates",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "tastingclasses",
+        "title": "Tasting Classes",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "tattoo",
+        "title": "Tattoo",
+        "parents": [
+            "beautysvc"
+        ]
+    },
+    {
+        "alias": "tattooremoval",
+        "title": "Tattoo Removal",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "tavolacalda",
+        "title": "Tavola Calda",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "taxidermy",
+        "title": "Taxidermy",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "SE",
+            "NZ",
+            "SG",
+            "IE",
+            "NL",
+            "CA",
+            "DK",
+            "BR",
+            "CZ",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "taxis",
+        "title": "Taxis",
+        "parents": [
+            "transport"
+        ]
+    },
+    {
+        "alias": "taxlaw",
+        "title": "Tax Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SG",
+            "US",
+            "FR",
+            "BE",
+            "BR",
+            "CZ",
+            "AU"
+        ]
+    },
+    {
+        "alias": "taxoffice",
+        "title": "Tax Office",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_blacklist": [
+            "US",
+            "ES",
+            "CA",
+            "PL",
+            "SG"
+        ]
+    },
+    {
+        "alias": "taxservices",
+        "title": "Tax Services",
+        "parents": [
+            "financialservices"
+        ]
+    },
+    {
+        "alias": "tcm",
+        "title": "Traditional Chinese Medicine",
+        "parents": [
+            "health"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "tea",
+        "title": "Tea Rooms",
+        "parents": [
+            "food"
+        ]
+    },
+    {
+        "alias": "teachersupplies",
+        "title": "Teacher Supplies",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "FR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "teambuilding",
+        "title": "Team Building Activities",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "teethwhitening",
+        "title": "Teeth Whitening",
+        "parents": [
+            "beautysvc"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "telecommunications",
+        "title": "Telecommunications",
+        "parents": [
+            "itservices"
+        ],
+        "country_blacklist": [
+            "MX",
+            "AR",
+            "JP",
+            "CL"
+        ]
+    },
+    {
+        "alias": "televisionserviceproviders",
+        "title": "Television Service Providers",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "televisionstations",
+        "title": "Television Stations",
+        "parents": [
+            "massmedia"
+        ]
+    },
+    {
+        "alias": "tempura",
+        "title": "Tempura",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "tenantlaw",
+        "title": "Tenant and Eviction Law",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "CZ"
+        ]
+    },
+    {
+        "alias": "tennis",
+        "title": "Tennis",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "teochew",
+        "title": "Teochew",
+        "parents": [
+            "chinese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "MY",
+            "HK"
+        ]
+    },
+    {
+        "alias": "teppanyaki",
+        "title": "Teppanyaki",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "JP",
+            "SG",
+            "TW",
+            "US",
+            "HK",
+            "MX",
+            "AU"
+        ]
+    },
+    {
+        "alias": "testprep",
+        "title": "Test Preparation",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "tex-mex",
+        "title": "Tex-Mex",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "PT",
+            "ES",
+            "DK",
+            "AU"
+        ]
+    },
+    {
+        "alias": "thai",
+        "title": "Thai",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "theater",
+        "title": "Performing Arts",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "themedcafes",
+        "title": "Themed Cafes",
+        "parents": [
+            "cafes"
+        ],
+        "country_whitelist": [
+            "DE",
+            "MY",
+            "JP",
+            "SG",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "NL",
+            "FR",
+            "BE",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "threadingservices",
+        "title": "Threading Services",
+        "parents": [
+            "hairremoval"
+        ]
+    },
+    {
+        "alias": "thrift_stores",
+        "title": "Thrift Stores",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "tickets",
+        "title": "Tickets",
+        "parents": [
+            "shopping"
+        ],
+        "country_whitelist": [
+            "SE",
+            "PT",
+            "DK",
+            "FI",
+            "CZ",
+            "PL",
+            "NO",
+            "CL"
+        ]
+    },
+    {
+        "alias": "ticketsales",
+        "title": "Ticket Sales",
+        "parents": [
+            "arts"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "ES",
+            "NL",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "tikibars",
+        "title": "Tiki Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "TR",
+            "DE",
+            "FR",
+            "CH",
+            "JP",
+            "PL",
+            "AT"
+        ]
+    },
+    {
+        "alias": "tiling",
+        "title": "Tiling",
+        "parents": [
+            "homeservices"
+        ],
+        "country_blacklist": [
+            "TR",
+            "MY",
+            "GB",
+            "JP",
+            "IE",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "NL",
+            "CA",
+            "BE",
+            "BR",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "tires",
+        "title": "Tires",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "titleloans",
+        "title": "Title Loans",
+        "parents": [
+            "financialservices"
+        ],
+        "country_whitelist": [
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "tobaccoshops",
+        "title": "Tobacco Shops",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "tofu",
+        "title": "Tofu Shops",
+        "parents": [
+            "gourmet"
+        ],
+        "country_whitelist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "tonkatsu",
+        "title": "Tonkatsu",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "torshi",
+        "title": "Torshi",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "tortillas",
+        "title": "Tortillas",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "tours",
+        "title": "Tours",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "towing",
+        "title": "Towing",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "towncarservice",
+        "title": "Town Car Service",
+        "parents": [
+            "transport"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "MY",
+            "GB",
+            "SG",
+            "IE",
+            "TW",
+            "US",
+            "PH",
+            "HK",
+            "NL",
+            "CA",
+            "BE",
+            "AU"
+        ]
+    },
+    {
+        "alias": "townhall",
+        "title": "Town Hall",
+        "parents": [
+            "publicservicesgovt"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "MY",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "TW",
+            "PH",
+            "HK",
+            "CA",
+            "AU",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "toxicologists",
+        "title": "Toxicologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "toys",
+        "title": "Toy Stores",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "tradamerican",
+        "title": "American (Traditional)",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "tradclothing",
+        "title": "Traditional Clothing",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "tradefairs",
+        "title": "Trade Fairs",
+        "parents": [
+            "festivals"
+        ],
+        "country_whitelist": [
+            "TR",
+            "DE",
+            "NZ",
+            "CH",
+            "JP",
+            "AT",
+            "PT",
+            "NL",
+            "DK",
+            "MX",
+            "BE",
+            "CZ",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "traditional_swedish",
+        "title": "Traditional Swedish",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "SE",
+            "FI"
+        ]
+    },
+    {
+        "alias": "trafficschools",
+        "title": "Traffic Schools",
+        "parents": [
+            "specialtyschools"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "trafficticketinglaw",
+        "title": "Traffic Ticketing Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "trailerdealers",
+        "title": "Trailer Dealers",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "CA",
+            "DK",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "trailerrental",
+        "title": "Trailer Rental",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "trailerrepair",
+        "title": "Trailer Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "CA",
+            "DK",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "trains",
+        "title": "Trains",
+        "parents": [
+            "transport"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "CH",
+            "JP",
+            "SG",
+            "AT",
+            "TW",
+            "ES",
+            "HK",
+            "MX",
+            "CL",
+            "MY",
+            "PH",
+            "AR",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "trainstations",
+        "title": "Train Stations",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "trampoline",
+        "title": "Trampoline Parks",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "NZ",
+            "MY",
+            "JP",
+            "SG",
+            "TW",
+            "ES",
+            "PH",
+            "HK",
+            "FR",
+            "AR",
+            "MX",
+            "BR",
+            "CL"
+        ]
+    },
+    {
+        "alias": "translationservices",
+        "title": "Translation Services",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "SE"
+        ]
+    },
+    {
+        "alias": "transmissionrepair",
+        "title": "Transmission Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "DE",
+            "PH",
+            "MY",
+            "CH",
+            "IT",
+            "AT"
+        ]
+    },
+    {
+        "alias": "transport",
+        "title": "Transportation",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "tras_os_montes",
+        "title": "Tras-os-Montes",
+        "parents": [
+            "portuguese"
+        ],
+        "country_whitelist": [
+            "PT"
+        ]
+    },
+    {
+        "alias": "trattorie",
+        "title": "Trattorie",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "FR",
+            "AR",
+            "CH",
+            "PL",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "travelagents",
+        "title": "Travel Agents",
+        "parents": [
+            "travelservices"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "travelservices",
+        "title": "Travel Services",
+        "parents": [
+            "hotelstravel"
+        ]
+    },
+    {
+        "alias": "treeservices",
+        "title": "Tree Services",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "trinidadian",
+        "title": "Trinidadian",
+        "parents": [
+            "caribbean"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "triviahosts",
+        "title": "Trivia Hosts",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "trophyshops",
+        "title": "Trophy Shops",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "NZ",
+            "BR",
+            "SG",
+            "FI"
+        ]
+    },
+    {
+        "alias": "tropicalmedicine",
+        "title": "Tropical Medicine",
+        "parents": [
+            "physicians"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NL",
+            "CH",
+            "BE",
+            "BR",
+            "IT",
+            "AT"
+        ]
+    },
+    {
+        "alias": "truck_rental",
+        "title": "Truck Rental",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "CH",
+            "JP",
+            "AT",
+            "NL",
+            "BE",
+            "CZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "truckdealers",
+        "title": "Commercial Truck Dealers",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "MY",
+            "JP",
+            "TW",
+            "PH",
+            "HK",
+            "CZ",
+            "PL",
+            "FI"
+        ]
+    },
+    {
+        "alias": "truckrepair",
+        "title": "Commercial Truck Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "SG",
+            "AT",
+            "ES",
+            "DK",
+            "MX",
+            "BE",
+            "CL",
+            "GB",
+            "IE",
+            "US",
+            "NL",
+            "FR",
+            "AR",
+            "CA",
+            "BR",
+            "AU",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "tubing",
+        "title": "Tubing",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "tuina",
+        "title": "Tui Na",
+        "parents": [
+            "tcm"
+        ]
+    },
+    {
+        "alias": "turkish",
+        "title": "Turkish",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "turkishravioli",
+        "title": "Turkish Ravioli",
+        "parents": [
+            "turkish"
+        ],
+        "country_whitelist": [
+            "TR"
+        ]
+    },
+    {
+        "alias": "tuscan",
+        "title": "Tuscan",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "US",
+            "IT"
+        ]
+    },
+    {
+        "alias": "tutoring",
+        "title": "Tutoring Centers",
+        "parents": [
+            "education"
+        ]
+    },
+    {
+        "alias": "tvmounting",
+        "title": "TV Mounting",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "NL",
+            "FR",
+            "BE",
+            "JP",
+            "IT"
+        ]
+    },
+    {
+        "alias": "udon",
+        "title": "Udon",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "SE",
+            "HK",
+            "DK",
+            "JP",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "ukrainian",
+        "title": "Ukrainian",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "ES",
+            "DK"
+        ]
+    },
+    {
+        "alias": "ultrasoundimagingcenters",
+        "title": "Ultrasound Imaging Centers",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "unagi",
+        "title": "Unagi",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "underseamedicine",
+        "title": "Undersea/Hyperbaric Medicine",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "uniforms",
+        "title": "Uniforms",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "CH",
+            "JP",
+            "IE",
+            "AT",
+            "NL",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "university_housing",
+        "title": "University Housing",
+        "parents": [
+            "realestate"
+        ]
+    },
+    {
+        "alias": "unofficialyelpevents",
+        "title": "Unofficial Yelp Events",
+        "parents": [
+            "localflavor"
+        ]
+    },
+    {
+        "alias": "urgent_care",
+        "title": "Urgent Care",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "urologists",
+        "title": "Urologists",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "usedbooks",
+        "title": "Used Bookstore",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "AR",
+            "CA",
+            "AU",
+            "CL"
+        ]
+    },
+    {
+        "alias": "usedcardealers",
+        "title": "Used Car Dealers",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "utilities",
+        "title": "Utilities",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "GB",
+            "SG",
+            "US",
+            "PT",
+            "NL",
+            "BE",
+            "CZ",
+            "AU",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "uzbek",
+        "title": "Uzbek",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "US",
+            "CZ"
+        ]
+    },
+    {
+        "alias": "vacation_rentals",
+        "title": "Vacation Rentals",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_blacklist": [
+            "SG"
+        ]
+    },
+    {
+        "alias": "vacationrentalagents",
+        "title": "Vacation Rental Agents",
+        "parents": [
+            "hotelstravel"
+        ],
+        "country_blacklist": [
+            "SG",
+            "ES"
+        ]
+    },
+    {
+        "alias": "valetservices",
+        "title": "Valet Services",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "TR",
+            "BR",
+            "US"
+        ]
+    },
+    {
+        "alias": "vapeshops",
+        "title": "Vape Shops",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "SG",
+            "BR"
+        ]
+    },
+    {
+        "alias": "vascularmedicine",
+        "title": "Vascular Medicine",
+        "parents": [
+            "physicians"
+        ]
+    },
+    {
+        "alias": "vegan",
+        "title": "Vegan",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "vegetarian",
+        "title": "Vegetarian",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "vehicleshipping",
+        "title": "Vehicle Shipping",
+        "parents": [
+            "auto"
+        ]
+    },
+    {
+        "alias": "vehiclewraps",
+        "title": "Vehicle Wraps",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "TR",
+            "BE",
+            "FR"
+        ]
+    },
+    {
+        "alias": "venetian",
+        "title": "Venetian",
+        "parents": [
+            "italian"
+        ],
+        "country_whitelist": [
+            "FR",
+            "IT"
+        ]
+    },
+    {
+        "alias": "venezuelan",
+        "title": "Venezuelan",
+        "parents": [
+            "latin"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "US",
+            "FR",
+            "AR",
+            "CA",
+            "CL"
+        ]
+    },
+    {
+        "alias": "venison",
+        "title": "Venison",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "CA",
+            "DK",
+            "CZ",
+            "AU",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "venues",
+        "title": "Venues & Event Spaces",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "vermouthbars",
+        "title": "Vermouth Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "TR",
+            "JP",
+            "FR",
+            "DK",
+            "BR",
+            "PL",
+            "NO",
+            "IT"
+        ]
+    },
+    {
+        "alias": "vet",
+        "title": "Veterinarians",
+        "parents": [
+            "pets"
+        ]
+    },
+    {
+        "alias": "veteransorganizations",
+        "title": "Veterans Organizations",
+        "parents": [
+            "social_clubs"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "videoandgames",
+        "title": "Videos & Video Game Rental",
+        "parents": [
+            "media"
+        ]
+    },
+    {
+        "alias": "videofilmproductions",
+        "title": "Video/Film Production",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "videogamestores",
+        "title": "Video Game Stores",
+        "parents": [
+            "media"
+        ]
+    },
+    {
+        "alias": "videographers",
+        "title": "Videographers",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "vietnamese",
+        "title": "Vietnamese",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "vintage",
+        "title": "Used, Vintage & Consignment",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "vinyl_records",
+        "title": "Vinyl Records",
+        "parents": [
+            "media"
+        ]
+    },
+    {
+        "alias": "vinylsiding",
+        "title": "Siding",
+        "parents": [
+            "homeservices"
+        ],
+        "country_whitelist": [
+            "SE",
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "NL",
+            "CA",
+            "DK",
+            "BE",
+            "AU",
+            "NO"
+        ]
+    },
+    {
+        "alias": "virtualrealitycenters",
+        "title": "Virtual Reality Centers",
+        "parents": [
+            "arts"
+        ]
+    },
+    {
+        "alias": "visitorcenters",
+        "title": "Visitor Centers",
+        "parents": [
+            "travelservices"
+        ]
+    },
+    {
+        "alias": "vitaminssupplements",
+        "title": "Vitamins & Supplements",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "MY",
+            "PH"
+        ]
+    },
+    {
+        "alias": "vocalcoach",
+        "title": "Vocal Coach",
+        "parents": [
+            "musicinstrumentservices"
+        ]
+    },
+    {
+        "alias": "vocation",
+        "title": "Vocational & Technical School",
+        "parents": [
+            "specialtyschools"
+        ]
+    },
+    {
+        "alias": "volleyball",
+        "title": "Volleyball",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "DE",
+            "SE",
+            "NZ",
+            "JP",
+            "SG",
+            "AT",
+            "FR",
+            "DK",
+            "BR",
+            "CZ",
+            "AU",
+            "NO",
+            "FI"
+        ]
+    },
+    {
+        "alias": "waffles",
+        "title": "Waffles",
+        "parents": [
+            "restaurants"
+        ]
+    },
+    {
+        "alias": "waldorfschools",
+        "title": "Waldorf Schools",
+        "parents": [
+            "education"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "walkinclinics",
+        "title": "Walk-in Clinics",
+        "parents": [
+            "medcenters"
+        ],
+        "country_blacklist": [
+            "DE",
+            "IT",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "walkingtours",
+        "title": "Walking Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "wallpapering",
+        "title": "Wallpapering",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "watch_repair",
+        "title": "Watch Repair",
+        "parents": [
+            "localservices"
+        ]
+    },
+    {
+        "alias": "watches",
+        "title": "Watches",
+        "parents": [
+            "shopping"
+        ]
+    },
+    {
+        "alias": "waterdelivery",
+        "title": "Water Delivery",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "PH",
+            "HK",
+            "CA",
+            "MY",
+            "BR"
+        ]
+    },
+    {
+        "alias": "waterheaterinstallrepair",
+        "title": "Water Heater Installation/Repair",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "waterparks",
+        "title": "Water Parks",
+        "parents": [
+            "active"
+        ],
+        "country_blacklist": [
+            "DE",
+            "NZ",
+            "MY",
+            "CH",
+            "GB",
+            "CL",
+            "IE",
+            "AT",
+            "HK",
+            "AR",
+            "AU",
+            "FI"
+        ]
+    },
+    {
+        "alias": "waterproofing",
+        "title": "Waterproofing",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "waterpurification",
+        "title": "Water Purification Services",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "waterstores",
+        "title": "Water Stores",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "MX",
+            "BR",
+            "CA",
+            "US"
+        ]
+    },
+    {
+        "alias": "watersuppliers",
+        "title": "Water Suppliers",
+        "parents": [
+            "utilities"
+        ]
+    },
+    {
+        "alias": "watertaxis",
+        "title": "Water Taxis",
+        "parents": [
+            "transport"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "MX",
+            "GB",
+            "AU",
+            "IT",
+            "IE"
+        ]
+    },
+    {
+        "alias": "waxing",
+        "title": "Waxing",
+        "parents": [
+            "hairremoval"
+        ]
+    },
+    {
+        "alias": "web_design",
+        "title": "Web Design",
+        "parents": [
+            "professional"
+        ]
+    },
+    {
+        "alias": "wedding_planning",
+        "title": "Wedding Planning",
+        "parents": [
+            "eventservices"
+        ]
+    },
+    {
+        "alias": "weddingchappels",
+        "title": "Wedding Chapels",
+        "parents": [
+            "eventservices"
+        ],
+        "country_whitelist": [
+            "US",
+            "JP",
+            "AU"
+        ]
+    },
+    {
+        "alias": "weightlosscenters",
+        "title": "Weight Loss Centers",
+        "parents": [
+            "health"
+        ]
+    },
+    {
+        "alias": "welldrilling",
+        "title": "Well Drilling",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "ES",
+            "US",
+            "AR",
+            "DK",
+            "MX",
+            "BR",
+            "CZ",
+            "PL",
+            "NO",
+            "IT",
+            "CL"
+        ]
+    },
+    {
+        "alias": "westernjapanese",
+        "title": "Western Style Japanese Food",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "whalewatchingtours",
+        "title": "Whale Watching Tours",
+        "parents": [
+            "tours"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "wheelrimrepair",
+        "title": "Wheel & Rim Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_whitelist": [
+            "US",
+            "IT",
+            "PT"
+        ]
+    },
+    {
+        "alias": "whiskeybars",
+        "title": "Whiskey Bars",
+        "parents": [
+            "bars"
+        ],
+        "country_blacklist": [
+            "IT"
+        ]
+    },
+    {
+        "alias": "wholesale_stores",
+        "title": "Wholesale Stores",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "wholesalers",
+        "title": "Wholesalers",
+        "parents": [
+            "professional"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "MY",
+            "TW",
+            "PH",
+            "HK",
+            "PT",
+            "FR",
+            "BR",
+            "CZ",
+            "FI"
+        ]
+    },
+    {
+        "alias": "wigs",
+        "title": "Wigs",
+        "parents": [
+            "shopping"
+        ],
+        "country_blacklist": [
+            "TR",
+            "SE",
+            "NZ",
+            "MY",
+            "CH",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "AT",
+            "TW",
+            "PH",
+            "HK",
+            "BR"
+        ]
+    },
+    {
+        "alias": "wildlifecontrol",
+        "title": "Wildlife Control",
+        "parents": [
+            "localservices"
+        ],
+        "country_blacklist": [
+            "JP"
+        ]
+    },
+    {
+        "alias": "wildlifehunting",
+        "title": "Wildlife Hunting Ranges",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "US"
+        ]
+    },
+    {
+        "alias": "willstrustsprobates",
+        "title": "Wills, Trusts, & Probates",
+        "parents": [
+            "estateplanning"
+        ],
+        "country_whitelist": [
+            "NZ",
+            "GB",
+            "SG",
+            "IE",
+            "US",
+            "NL",
+            "CA",
+            "BE",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "windowsinstallation",
+        "title": "Windows Installation",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "windowwashing",
+        "title": "Window Washing",
+        "parents": [
+            "homeservices"
+        ]
+    },
+    {
+        "alias": "windshieldinstallrepair",
+        "title": "Windshield Installation & Repair",
+        "parents": [
+            "auto"
+        ],
+        "country_blacklist": [
+            "DE",
+            "CZ",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "wine_bars",
+        "title": "Wine Bars",
+        "parents": [
+            "bars"
+        ]
+    },
+    {
+        "alias": "wineries",
+        "title": "Wineries",
+        "parents": [
+            "arts",
+            "food"
+        ],
+        "country_blacklist": [
+            "FI"
+        ]
+    },
+    {
+        "alias": "winetasteclasses",
+        "title": "Wine Tasting Classes",
+        "parents": [
+            "tastingclasses"
+        ]
+    },
+    {
+        "alias": "winetastingroom",
+        "title": "Wine Tasting Room",
+        "parents": [
+            "wineries"
+        ]
+    },
+    {
+        "alias": "winetours",
+        "title": "Wine Tours",
+        "parents": [
+            "tours"
+        ]
+    },
+    {
+        "alias": "wok",
+        "title": "Wok",
+        "parents": [
+            "restaurants"
+        ],
+        "country_blacklist": [
+            "TR",
+            "NZ",
+            "GB",
+            "JP",
+            "SG",
+            "IE",
+            "TW",
+            "US",
+            "HK",
+            "AR",
+            "CA",
+            "BR",
+            "AU",
+            "PL",
+            "IT"
+        ]
+    },
+    {
+        "alias": "womenscloth",
+        "title": "Women's Clothing",
+        "parents": [
+            "fashion"
+        ]
+    },
+    {
+        "alias": "workerscomplaw",
+        "title": "Workers Compensation Law",
+        "parents": [
+            "lawyers"
+        ],
+        "country_blacklist": [
+            "FR",
+            "DE",
+            "CH",
+            "AT"
+        ]
+    },
+    {
+        "alias": "wraps",
+        "title": "Wraps",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "TR",
+            "US",
+            "SE",
+            "PT",
+            "DK",
+            "CZ",
+            "NO"
+        ]
+    },
+    {
+        "alias": "xmasmarkets",
+        "title": "Christmas Markets",
+        "parents": [
+            "festivals"
+        ],
+        "country_blacklist": [
+            "TR",
+            "US",
+            "CA",
+            "NZ",
+            "BR",
+            "SG",
+            "IE"
+        ]
+    },
+    {
+        "alias": "yakiniku",
+        "title": "Yakiniku",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "yakitori",
+        "title": "Yakitori",
+        "parents": [
+            "japanese"
+        ],
+        "country_whitelist": [
+            "SG",
+            "TW",
+            "JP"
+        ]
+    },
+    {
+        "alias": "yelpevents",
+        "title": "Yelp Events",
+        "parents": [
+            "localflavor"
+        ]
+    },
+    {
+        "alias": "yoga",
+        "title": "Yoga",
+        "parents": [
+            "fitness"
+        ]
+    },
+    {
+        "alias": "youth_club",
+        "title": "Youth Club",
+        "parents": [
+            "localservices"
+        ],
+        "country_whitelist": [
+            "DE",
+            "NZ",
+            "CH",
+            "SG",
+            "DK",
+            "BE",
+            "CZ",
+            "SE",
+            "GB",
+            "IE",
+            "PT",
+            "NL",
+            "FR",
+            "CA",
+            "AU",
+            "NO",
+            "IT",
+            "FI"
+        ]
+    },
+    {
+        "alias": "yucatan",
+        "title": "Yucatan",
+        "parents": [
+            "mexican"
+        ],
+        "country_whitelist": [
+            "MX"
+        ]
+    },
+    {
+        "alias": "yugoslav",
+        "title": "Yugoslav",
+        "parents": [
+            "restaurants"
+        ],
+        "country_whitelist": [
+            "PT",
+            "SE",
+            "FR",
+            "BE",
+            "AU",
+            "IT"
+        ]
+    },
+    {
+        "alias": "zapiekanka",
+        "title": "Zapiekanka",
+        "parents": [
+            "food"
+        ],
+        "country_whitelist": [
+            "PL"
+        ]
+    },
+    {
+        "alias": "zipline",
+        "title": "Ziplining",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "zoos",
+        "title": "Zoos",
+        "parents": [
+            "active"
+        ]
+    },
+    {
+        "alias": "zorbing",
+        "title": "Zorbing",
+        "parents": [
+            "active"
+        ],
+        "country_whitelist": [
+            "ES",
+            "PT",
+            "US",
+            "NZ",
+            "MX",
+            "CZ"
+        ]
+    }
+]

--- a/install.sh
+++ b/install.sh
@@ -4,4 +4,5 @@
 # @Last Modified time: 2018-02-20 06:55:42
 
 virtualenv prod
+source prod/bin/activate
 pip install -r requirements.txt

--- a/run.sh
+++ b/run.sh
@@ -4,4 +4,4 @@
 # @Last Modified time: 2018-02-20 06:56:28
 
 source prod/bin/activate
-python3 search_yelp_places_server.py
+python search_yelp_places_server.py

--- a/search_yelp_places_server.py
+++ b/search_yelp_places_server.py
@@ -2,7 +2,7 @@
 # @Author: youralien
 # @Date:   2018-02-20 02:05:38
 # @Last Modified by:   youralien
-# @Last Modified time: 2018-06-28 14:45:31
+# @Last Modified time: 2018-06-28 16:13:28
 
 from flask import Flask, jsonify
 
@@ -29,7 +29,8 @@ def retrieve_yelp_categories(query):
                                               top_n=25)
 
     categories = set(cats_tfidf["feature"].get_values())
-    categories.remove('')   # depreciated
+    if '' in categories:
+        categories.remove('')   # depreciated
     categories = list(categories)
     return jsonify(categories)
 

--- a/search_yelp_places_server.py
+++ b/search_yelp_places_server.py
@@ -2,17 +2,19 @@
 # @Author: youralien
 # @Date:   2018-02-20 02:05:38
 # @Last Modified by:   youralien
-# @Last Modified time: 2018-02-20 06:31:12
+# @Last Modified time: 2018-06-28 14:45:31
 
 from flask import Flask, jsonify
 
 from affordance_language import natlang2keywords
 from yelp_academic_etl import (
-    load_tfidf, query_categories_by_many, query_categories_by_word)
+    load_tfidf, query_categories_by_many, query_categories_by_word,
+    category_title2alias)
 
 app = Flask(__name__)
 
 X, cats, vocab = load_tfidf("sklearn-with-stopwords")
+cats = category_title2alias(cats)
 
 
 @app.route("/categories/<string:query>/")
@@ -26,9 +28,9 @@ def retrieve_yelp_categories(query):
         cats_tfidf = query_categories_by_many(keywords, X, cats, vocab,
                                               top_n=25)
 
-    categories = list(cats_tfidf["feature"].get_values())
-
-    print(categories)
+    categories = set(cats_tfidf["feature"].get_values())
+    categories.remove('')   # depreciated
+    categories = list(categories)
     return jsonify(categories)
 
 

--- a/yelp_academic_etl.py
+++ b/yelp_academic_etl.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pickle
 import numpy as np
 import pandas as pd
@@ -88,4 +89,65 @@ def load_tfidf(fileprefix):
                     'tfidf/%s-X.mtx' % fileprefix))
     meta = np.load(os.path.join(os.path.dirname(__file__),
                    'tfidf/%s-meta.npz' % fileprefix))
+
     return X, meta['categories'], meta['vocabulary']
+
+
+def title2alias_dict(v3file='categories.json'):
+    """ Converts v2 titles to v3 aliases.
+    For example, kv["Shopping"] = 'shopping'
+
+    Parameters
+    ----------
+    v3file: path to v3 file
+    category_titles: list of category titles
+    """
+    v3_cats_json = json.load(open(v3file, 'r'))
+    kv = {cat['title']: cat['alias'] for cat in v3_cats_json}
+
+    # handcoded translation from v2 titles to v3 aliases
+    # FIXME: some of the aliases
+    depreciated_titles_aliases = {
+        '& Probates': 'willstrustsprobates',
+        'Beer': 'beer_and_wine',
+        'Books': 'media',
+        'Ethic Grocery': 'ethicgrocery',
+        'Mags': 'media',
+        'Music & Video': 'media',
+        'Pet Boarding/Pet Sitting': 'pet_sitting',  # petboarding too
+        'Psychics & Astrologers': 'astrologers',    # psychics too
+        'Trusts': 'willstrustsprobates',
+        'Used': 'vintage',
+        'Vintage & Consignment': 'vintage',
+        'Vinyl Siding': 'vinylsiding',
+        'Wills': 'willstrustsprobates',
+        'Wine & Spirits': 'beer_and_wine',
+        'Dry Cleaning & Laundry': 'laundromat',     # dryclean too
+    }
+
+    kv.update(depreciated_titles_aliases)
+
+    return kv
+
+
+def category_title2alias(categories):
+    """
+    Parameters
+    ----------
+    categories: list of strings
+        yelp category titles
+
+    Returns
+    -------
+    aliases: list of strings
+        yelp category aliases
+    """
+
+    title2alias = title2alias_dict()
+    aliases = []
+    for cat_title in categories:
+        try:
+            aliases.append(title2alias[cat_title])
+        except KeyError:
+            aliases.append('')
+    return aliases


### PR DESCRIPTION
Summary: Yelp V2 is using some depreciated categories. So we hard coded
translations to the V3 aliases. Now, all the categories returned are in
alias format